### PR TITLE
consumers with autodelivery no longer run out of link credit

### DIFF
--- a/mqlight/src/main/java/com/ibm/mqlight/api/impl/NonBlockingClientImpl.java
+++ b/mqlight/src/main/java/com/ibm/mqlight/api/impl/NonBlockingClientImpl.java
@@ -1310,9 +1310,7 @@ public class NonBlockingClientImpl extends NonBlockingClient implements FSMActio
         logger.entry(this, methodName, request);
 
         boolean result = pendingDeliveries.remove(request);
-        if (result) {
-            engine.tell(new DeliveryResponse(request), this);
-        }
+        engine.tell(new DeliveryResponse(request), this);
 
         logger.exit(this, methodName, result);
 


### PR DESCRIPTION
A consumer with autoConfirm=true would run out of link credit as
no DeliverResponse would be generated when the DeliveryRequest
was not present in the pendingDeliveries Set.

All deliveries will now generate a DeliveryResponse which will
trigger flow responses back to the broker to ensure the link
credit is not exhausted.
