### PR TITLE
Increase KeepAliveTime on TimerServiceImpl thread pool to 2seconds

### DIFF
--- a/mqlight/src/main/java/com/ibm/mqlight/api/impl/timer/TimerServiceImpl.java
+++ b/mqlight/src/main/java/com/ibm/mqlight/api/impl/timer/TimerServiceImpl.java
@@ -36,8 +36,6 @@ public class TimerServiceImpl implements TimerService {
 
     static {
         executor = new ScheduledThreadPoolExecutor(1);
-        executor.setKeepAliveTime(500, TimeUnit.MILLISECONDS);
-        executor.allowCoreThreadTimeOut(true);
         executor.setRemoveOnCancelPolicy(true);
     }
 


### PR DESCRIPTION
The mqlight broker uses an idle time of 1.5 seconds so a task will
be scheduled at least that often.  By increasing the idle time to
2 seconds the TimerServiceImpl will re-use the existing core thread
rather than re-create for every task.

Fixes #7
