### PR TITLE
Dont make core threads timeout on TimerServiceImpl

### DIFF
--- a/mqlight/src/main/java/com/ibm/mqlight/api/impl/timer/TimerServiceImpl.java
+++ b/mqlight/src/main/java/com/ibm/mqlight/api/impl/timer/TimerServiceImpl.java
@@ -36,8 +36,6 @@ public class TimerServiceImpl implements TimerService {
 
     static {
         executor = new ScheduledThreadPoolExecutor(1);
-        executor.setKeepAliveTime(500, TimeUnit.MILLISECONDS);
-        executor.allowCoreThreadTimeOut(true);
         executor.setRemoveOnCancelPolicy(true);
     }
 


### PR DESCRIPTION
This setting is causing the Threads to be shutdown after every
task however since there are always jobs to run we can just
leave the thread alive.  At worst this leaves 1 idle thread.

Fixes #7
