### PR TITLE
Various code cleanups to remove warnings

### DIFF
--- a/mqlight/src/main/java/com/ibm/mqlight/api/ClientOptions.java
+++ b/mqlight/src/main/java/com/ibm/mqlight/api/ClientOptions.java
@@ -35,7 +35,7 @@ import com.ibm.mqlight.api.logging.LoggerFactory;
 public class ClientOptions {
 
     private static final Logger logger = LoggerFactory.getLogger(ClientOptions.class);
-  
+
     private final String id;
     private final String user;
     private final String password;
@@ -45,13 +45,13 @@ public class ClientOptions {
     private ClientOptions(String id, String user, String password, File certFile, boolean verifyName) {
         final String methodName = "<init>";
         logger.entry(this, methodName, id, user, "******", certFile, verifyName);
-      
+
         this.id = id;
         this.user = user;
         this.password = password;
         this.certFile = certFile;
         this.verifyName = verifyName;
-        
+
         logger.exit(this, methodName);
     }
 
@@ -77,19 +77,12 @@ public class ClientOptions {
 
     @Override
     public String toString() {
-        StringBuilder sb = new StringBuilder(super.toString());
-        sb.append(" [id=")
-          .append(id)
-          .append(", user=")
-          .append(user)
-          .append(", password=")
-          .append(password == null ? null : "******")
-          .append(", certFile=")
-          .append(certFile)
-          .append(", verifyName=")
-          .append(verifyName)
-          .append("]");
-        return sb.toString();
+        return super.toString()
+                + " [id=" + id
+                + ", user=" + user
+                + ", password=" + (password == null ? null : "******")
+                + ", certFile=" + certFile
+                + ", verifyName=" + verifyName + "]";
     }
 
     /**
@@ -132,7 +125,7 @@ public class ClientOptions {
         public ClientOptionsBuilder setId(String id) throws IllegalArgumentException {
             final String methodName = "setId";
             logger.entry(this, methodName, id);
-          
+
             if (id != null) {
                 if (id.length() > 256) {
                   final IllegalArgumentException exception = new IllegalArgumentException("Client identifier '" + id + "' is longer than the maximum ID length of 256.");
@@ -152,9 +145,9 @@ public class ClientOptions {
                 }
             }
             this.id = id;
-            
+
             logger.exit(this, methodName, this);
-            
+
             return this;
         }
 
@@ -177,7 +170,7 @@ public class ClientOptions {
          * Specifies a X.509 certificate chain file for SSL/TLS certificates
          * that the client will trust. This can either be a file in PEM format
          * or a Java KeyStore (JKS) file.
-         * 
+         *
          * @param certificateFile
          *            a trust store that contains SSL/TLS certificates that the
          *            client is to trust. If this is not set (or is set to null)

--- a/mqlight/src/main/java/com/ibm/mqlight/api/Delivery.java
+++ b/mqlight/src/main/java/com/ibm/mqlight/api/Delivery.java
@@ -32,7 +32,7 @@ public interface Delivery {
      */
     enum Type {
         BYTES, STRING, MALFORMED, JSON
-    };
+    }
 
     /**
      * @return the type of the delivery.  This is provided to simplify casting this

--- a/mqlight/src/main/java/com/ibm/mqlight/api/JsonDelivery.java
+++ b/mqlight/src/main/java/com/ibm/mqlight/api/JsonDelivery.java
@@ -57,7 +57,7 @@ public interface JsonDelivery {
      * @throws JsonParseException if the data is not valid JSON.
      * @throws JsonSyntaxException if the data contains malformed JSON elements.
      */
-    JsonElement getData() throws JsonParseException, JsonSyntaxException;
+    JsonElement getData() throws JsonParseException;
 
     /**
      * @return a <code>String</code> representation of the JSON.  This allows other parsers to be used.

--- a/mqlight/src/main/java/com/ibm/mqlight/api/SendOptions.java
+++ b/mqlight/src/main/java/com/ibm/mqlight/api/SendOptions.java
@@ -33,17 +33,17 @@ import com.ibm.mqlight.api.logging.LoggerFactory;
 public class SendOptions {
 
     private static final Logger logger = LoggerFactory.getLogger(SendOptions.class);
-  
+
     private final QOS qos;
     private final long ttl;
 
     private SendOptions(QOS qos, long ttl) {
         final String methodName = "<init>";
         logger.entry(this, methodName, qos, ttl);
-      
+
         this.qos = qos;
         this.ttl = ttl;
-        
+
         logger.exit(this, methodName);
     }
 
@@ -57,13 +57,9 @@ public class SendOptions {
 
     @Override
     public String toString() {
-        StringBuilder sb = new StringBuilder(super.toString());
-        sb.append(" [qos=")
-          .append(qos)
-          .append(", ttl=")
-          .append(ttl)
-          .append("]");
-        return sb.toString();
+        return super.toString()
+                + " [qos=" + qos
+                + ", ttl=" + ttl + "]";
     }
 
     /**
@@ -94,16 +90,16 @@ public class SendOptions {
         public SendOptionsBuilder setQos(QOS qos) throws IllegalArgumentException {
             final String methodName = "setQos";
             logger.entry(this, methodName, qos);
-          
+
             if (qos == null) {
               final IllegalArgumentException exception = new IllegalArgumentException("qos argument cannot be null");
               logger.throwing(this,  methodName, exception);
               throw exception;
             }
             this.qos = qos;
-            
+
             logger.exit(this, methodName, this);
-            
+
             return this;
         }
 
@@ -117,16 +113,16 @@ public class SendOptions {
         public SendOptionsBuilder setTtl(long ttl) throws IllegalArgumentException {
             final String methodName = "setTtl";
             logger.entry(this, methodName, ttl);
-          
+
             if (ttl < 1 || ttl > 4294967295L) {
               final IllegalArgumentException exception = new IllegalArgumentException("ttl value '" + ttl + "' is invalid, must be an unsigned non-zero integer number");
               logger.throwing(this,  methodName, exception);
               throw exception;
             }
             this.ttl = ttl;
-            
+
             logger.exit(this, methodName, this);
-            
+
             return this;
         }
 

--- a/mqlight/src/main/java/com/ibm/mqlight/api/SubscribeOptions.java
+++ b/mqlight/src/main/java/com/ibm/mqlight/api/SubscribeOptions.java
@@ -34,7 +34,7 @@ import com.ibm.mqlight.api.logging.LoggerFactory;
 public class SubscribeOptions {
 
     private static final Logger logger = LoggerFactory.getLogger(SubscribeOptions.class);
-  
+
     private final boolean autoConfirm;
     private final int credit;
     private final QOS qos;
@@ -44,13 +44,13 @@ public class SubscribeOptions {
     private SubscribeOptions(boolean autoConfirm, int credit, QOS qos, String shareName, long ttl) {
         final String methodName = "<init>";
         logger.entry(this, methodName, autoConfirm, credit, qos, shareName, ttl);
-      
+
         this.autoConfirm = autoConfirm;
         this.credit = credit;
         this.qos = qos;
         this.shareName = shareName;
         this.ttl = ttl;
-        
+
         logger.exit(this, methodName);
     }
 
@@ -76,19 +76,12 @@ public class SubscribeOptions {
 
     @Override
     public String toString() {
-        StringBuilder sb = new StringBuilder(super.toString());
-        sb.append(" [autoConfirm=")
-          .append(autoConfirm)
-          .append(", credit=")
-          .append(credit)
-          .append(", qos=")
-          .append(qos)
-          .append(", share=")
-          .append(shareName)
-          .append(", ttl=")
-          .append(ttl)
-          .append("]");
-        return sb.toString();
+        return super.toString()
+                + " [autoConfirm=" + autoConfirm
+                + ", credit=" + credit
+                + ", qos=" + qos
+                + ", share=" + shareName
+                + ", ttl=" + ttl + "]";
     }
 
     /**
@@ -141,16 +134,16 @@ public class SubscribeOptions {
         public SubscribeOptionsBuilder setCredit(int credit) throws IllegalArgumentException {
             final String methodName = "setCredit";
             logger.entry(this, methodName, credit);
-          
+
             if (credit < 0) {
               final IllegalArgumentException exception = new IllegalArgumentException("Credit value '" + credit + "' is invalid, must be >= 0");
               logger.throwing(this,  methodName, exception);
               throw exception;
             }
             this.credit = credit;
-            
+
             logger.exit(this, methodName, this);
-            
+
             return this;
         }
 
@@ -164,16 +157,16 @@ public class SubscribeOptions {
         public SubscribeOptionsBuilder setQos(QOS qos) throws IllegalArgumentException {
             final String methodName = "setQos";
             logger.entry(this, methodName, qos);
-          
+
             if (qos == null) {
               final IllegalArgumentException exception = new IllegalArgumentException("QOS value cannot be null");
               logger.throwing(this,  methodName, exception);
               throw exception;
             }
             this.qos = qos;
-            
+
             logger.exit(this, methodName, this);
-            
+
             return this;
         }
 
@@ -182,23 +175,23 @@ public class SubscribeOptions {
          * @param shareName the share argument used to subscribe to a destination.  The
          *                  default is <code>null</code> which is interpreted as "do not subscribe
          *                  to a shared destination - the destination is private to this client".
-         *                  When specified, the share name must not contain a colon (:) character. 
+         *                  When specified, the share name must not contain a colon (:) character.
          * @return the instance of <code>SubscribeOptionsBuilder</code> that this method was invoked on.
          * @throws IllegalArgumentException if an invalid <code>shareName</code> value is specified.
          */
         public SubscribeOptionsBuilder setShare(String shareName) throws IllegalArgumentException {
             final String methodName = "setShare";
             logger.entry(this, methodName, shareName);
-          
+
             if (shareName != null && shareName.contains(":")) {
               final IllegalArgumentException exception = new IllegalArgumentException("Share name cannot contain a colon (:) character");
               logger.throwing(this,  methodName, exception);
               throw exception;
             }
             this.shareName = shareName;
-            
+
             logger.exit(this, methodName, this);
-            
+
             return this;
         }
 
@@ -208,7 +201,7 @@ public class SubscribeOptions {
          * there are no instances of a client subscribed to a destination. It is reset each time a new instance of the client
          * subscribes to the destination. If time to live counts down to zero then MQ Light will delete the destination by
          * discarding any messages held at the destination and not accruing any new messages.
-         * 
+         *
          * @param ttl
          *            a time to live value in milliseconds, the default being 0 - meaning the destination will be deleted as
          *            soon as there are no clients subscribed to it. This must be a positive value, and when converted to
@@ -220,20 +213,20 @@ public class SubscribeOptions {
         public SubscribeOptionsBuilder setTtl(long ttl) throws IllegalArgumentException {
             final String methodName = "setTtl";
             logger.entry(this, methodName, ttl);
-            
+
             setTtl(ttl, TimeUnit.MILLISECONDS);
 
             logger.exit(this, methodName, this);
             return this;
         }
-        
+
         /**
          * A time-to-live value that is applied to the destination that the client is subscribed to. This value will replace any
          * previous value, if the destination already exists. Time to live starts counting down when there are no instances of a
          * client subscribed to a destination. It is reset each time a new instance of the client subscribes to the destination.
          * If time to live counts down to zero then MQ Light will delete the destination by discarding any messages held at the
          * destination and not accruing any new messages.
-         * 
+         *
          * @param ttl
          *            a time to live value in the given {@link TimeUnit}, the default being 0 - meaning the destination will be
          *            deleted as soon as there are no clients subscribed to it. This must be a positive value, and a maximum of
@@ -256,11 +249,11 @@ public class SubscribeOptions {
                 throw exception;
             }
             this.ttl = ttl;
-            
+
             logger.exit(this, methodName, this);
-            
+
             return this;
-        }        
+        }
 
         /**
          * @return an instance of SubscribeOptions based on the current settings of

--- a/mqlight/src/main/java/com/ibm/mqlight/api/endpoint/EndpointPromise.java
+++ b/mqlight/src/main/java/com/ibm/mqlight/api/endpoint/EndpointPromise.java
@@ -31,14 +31,14 @@ import com.ibm.mqlight.api.Promise;
  * time before making more endpoint lookup requests
  */
 public interface EndpointPromise extends Promise<Endpoint>{
-    
+
     /**
      * Completes the promise and indicates to the client that it should
      * wait for a period of time before querying the endpoint service again.
-     * 
+     *
      * @param delay a wait time in milliseconds.
      * @throws IllegalStateException if this method is invoked when the promise
      *                               has already been completed.
      */
-    public void setWait(long delay) throws IllegalStateException;
+    void setWait(long delay) throws IllegalStateException;
 }

--- a/mqlight/src/main/java/com/ibm/mqlight/api/impl/Component.java
+++ b/mqlight/src/main/java/com/ibm/mqlight/api/impl/Component.java
@@ -19,5 +19,5 @@
 package com.ibm.mqlight.api.impl;
 
 public interface Component {
-  public void tell(Message message, Component self);
+  void tell(Message message, Component self);
 }

--- a/mqlight/src/main/java/com/ibm/mqlight/api/impl/ComponentImpl.java
+++ b/mqlight/src/main/java/com/ibm/mqlight/api/impl/ComponentImpl.java
@@ -25,40 +25,40 @@ import com.ibm.mqlight.api.logging.Logger;
 import com.ibm.mqlight.api.logging.LoggerFactory;
 
 public abstract class ComponentImpl implements Component {
-    
+
     private static final Logger logger = LoggerFactory.getLogger(ComponentImpl.class);
-    
+
     public static final ComponentImpl NOBODY = new ComponentImpl() {
         public void tell(Message message, Component self) {}
         @Override protected void onReceive(Message message) {
           logger.data(this, "tell", message);
         }
     };
-    
+
     private final LinkedList<Message> queue = new LinkedList<>();
     private boolean scheduled = false;
     protected final Object componentMonitor = new Object();
-    
+
     public void tell(Message message, Component self) {
         final String methodName = "tell";
         logger.entry(this, methodName, message, self);
 
         message.setSender(self);
-        boolean execute = false;
+        boolean execute;
         synchronized(queue) {
             queue.addLast(message);
             execute = !scheduled;
             if (execute) scheduled = true;
         }
         if (execute) deliverMessages();
-        
+
         logger.exit(this, methodName);
     }
-    
+
     private void deliverMessages() {
         final String methodName = "deliverMessages";
         logger.entry(this, methodName);
-      
+
         while(true) {
             Message message = null;
             synchronized(queue) {
@@ -76,9 +76,9 @@ public abstract class ComponentImpl implements Component {
               }
             }
         }
-        
+
         logger.exit(this, methodName);
     }
-    
+
     protected abstract void onReceive(Message message);
 }

--- a/mqlight/src/main/java/com/ibm/mqlight/api/impl/DestinationListenerWrapper.java
+++ b/mqlight/src/main/java/com/ibm/mqlight/api/impl/DestinationListenerWrapper.java
@@ -122,7 +122,7 @@ class DestinationListenerWrapper<T> {
                     payloadBytes = data;
                 }
 
-                Map<String, Object> properties = new HashMap<String, Object>();
+                Map<String, Object> properties = new HashMap<>();
                 if (malformedReason == null) {
                     Object msgBodyValue = ((AmqpValue)msg.getBody()).getValue();
                     if (msgBodyValue instanceof Binary) {
@@ -180,10 +180,9 @@ class DestinationListenerWrapper<T> {
 
                     if (msg.getDeliveryAnnotations() != null) {
                         Map<Symbol, Object> annotations = msg.getDeliveryAnnotations().getValue();
-                        String condition = null;
                         if (annotations.containsKey(malformedConditionSymbol) &&
                             annotations.get(malformedConditionSymbol) instanceof Symbol) {
-                            condition = ((Symbol)annotations.get(malformedConditionSymbol)).toString();
+                            String condition = annotations.get(malformedConditionSymbol).toString();
                             if (condition.equals("FORMATNOMAPPING")) {
                                 malformedReason = MalformedDelivery.MalformedReason.FORMATNOMAPPING;
                             } else if (condition.equals("JMSNOMAPPING")) {

--- a/mqlight/src/main/java/com/ibm/mqlight/api/impl/FSMActions.java
+++ b/mqlight/src/main/java/com/ibm/mqlight/api/impl/FSMActions.java
@@ -20,56 +20,56 @@ package com.ibm.mqlight.api.impl;
 
 public interface FSMActions {
 
-    public void startTimer();
-    
-    public void openConnection();
-    
-    public void closeConnection();
-    
-    public void cancelTimer();
-    
-    public void requestEndpoint();
-    
+    void startTimer();
+
+    void openConnection();
+
+    void closeConnection();
+
+    void cancelTimer();
+
+    void requestEndpoint();
+
     /**
      * This action remakes the client's subscriptions.
      * <p>
      * The action is invoked whenever a connection is recovered.
      */
-    public void remakeInboundLinks();
-    
-    public void blessEndpoint();
-    
+    void remakeInboundLinks();
+
+    void blessEndpoint();
+
     /**
      * This action performs the cleanup operations such as flushing/failing any pending sends or subscribes.
      * <p>
      * The action can be invoked when a client is stopping.
      */
-    public void cleanup();
-    
-    public void failPendingStops();
-    
-    public void succeedPendingStops();
-    
-    public void failPendingStarts();
-    
-    public void succeedPendingStarts();
-    
+    void cleanup();
+
+    void failPendingStops();
+
+    void succeedPendingStops();
+
+    void failPendingStarts();
+
+    void succeedPendingStarts();
+
     // All of these relate to external state machine transitions
-    public void eventStarting();
-    public void eventUserStopping();
-    public void eventSystemStopping();
-    public void eventStopped();
-    public void eventStarted();
-    public void eventRetrying();
-    public void eventRestarted();
+    void eventStarting();
+    void eventUserStopping();
+    void eventSystemStopping();
+    void eventStopped();
+    void eventStarted();
+    void eventRetrying();
+    void eventRestarted();
 
     /**
      * This action breaks any pending sends and subscription requests from the client
      * <p>
      * The action is invoked whenever a network error occurs and the client is not stopping.
      */
-    public void breakInboundLinks();
-    
-    public void processQueuedActions();
+    void breakInboundLinks();
+
+    void processQueuedActions();
 
 }

--- a/mqlight/src/main/java/com/ibm/mqlight/api/impl/InternalSend.java
+++ b/mqlight/src/main/java/com/ibm/mqlight/api/impl/InternalSend.java
@@ -37,7 +37,7 @@ class InternalSend<T> extends Message implements QueueableWork {
         final String methodName = "<init>";
         logger.entry(this, methodName, client, topic, qos, buf, length);
 
-        this.future = new CompletionFuture<T>(client);
+        this.future = new CompletionFuture<>(client);
         this.topic = topic;
         this.qos = qos;
         this.buf = buf;

--- a/mqlight/src/main/java/com/ibm/mqlight/api/impl/InternalSubscribe.java
+++ b/mqlight/src/main/java/com/ibm/mqlight/api/impl/InternalSubscribe.java
@@ -25,9 +25,9 @@ import com.ibm.mqlight.api.logging.Logger;
 import com.ibm.mqlight.api.logging.LoggerFactory;
 
 class InternalSubscribe<T> extends Message implements QueueableWork {
-  
+
     private static final Logger logger = LoggerFactory.getLogger(InternalSubscribe.class);
-  
+
     final CompletionFuture<T> future;
     final SubscriptionTopic topic;
     final QOS qos;
@@ -40,15 +40,15 @@ class InternalSubscribe<T> extends Message implements QueueableWork {
                       GsonBuilder gsonBuilder, DestinationListener<T> destListener, T context) {
         final String methodName = "<init>";
         logger.entry(this, methodName, client, topic, qos, credit, autoConfirm, ttl, gsonBuilder, destListener, context);
-      
+
         future = new CompletionFuture<>(client);
         this.topic = topic;
         this.qos = qos;
         this.credit = credit;
         this.autoConfirm = autoConfirm;
         this.ttl = ttl;
-        this.destListener = new DestinationListenerWrapper<T>(client, gsonBuilder, destListener, context);
-        
+        this.destListener = new DestinationListenerWrapper<>(client, gsonBuilder, destListener, context);
+
         logger.exit(this, methodName);
     }
 }

--- a/mqlight/src/main/java/com/ibm/mqlight/api/impl/MalformedDeliveryImpl.java
+++ b/mqlight/src/main/java/com/ibm/mqlight/api/impl/MalformedDeliveryImpl.java
@@ -30,25 +30,25 @@ import com.ibm.mqlight.api.logging.LoggerFactory;
 public class MalformedDeliveryImpl extends BytesDeliveryImpl implements MalformedDelivery {
 
     private static final Logger logger = LoggerFactory.getLogger(MalformedDeliveryImpl.class);
-  
+
     private final MalformedReason reason;
     private final String description;
     private final String format;
     private final int ccsid;
-    
+
     protected MalformedDeliveryImpl(NonBlockingClientImpl client, QOS qos, String shareName, String topic, String topicPattern, long ttl,
                                     ByteBuffer data, Map<String, Object> properties, DeliveryRequest req, MalformedReason reason,
                                     String malformedDescription, String malformedMQMDFormat, int malformedMQMDCCSID) {
         super(client, qos, shareName, topic, topicPattern, ttl, data, properties, req);
-        
+
         final String methodName = "<init>";
         logger.entry(this, methodName, client, qos, shareName, topic, topicPattern, ttl, data, properties, req, reason, malformedDescription, malformedMQMDFormat, malformedMQMDCCSID);
-        
+
         this.reason = reason;
         this.description = malformedDescription;
         this.format = malformedMQMDFormat;
         this.ccsid = malformedMQMDCCSID;
-        
+
         logger.exit(this, methodName);
     }
 
@@ -56,39 +56,37 @@ public class MalformedDeliveryImpl extends BytesDeliveryImpl implements Malforme
     public Type getType() {
         return Type.MALFORMED;
     }
-    
+
     public MalformedReason getReason() {
         return reason;
     }
-    
+
     public String getDescription() {
         return description;
     }
-    
+
     public String getMQMDFormat() {
         return format;
     }
-    
+
     public int getMQMDCodedCharSetId() {
         return ccsid;
     }
-    
+
     @Override
     public String toString() {
-        StringBuilder sb = new StringBuilder(getClass().getCanonicalName());
-        sb.append("@").append(Integer.toHexString(hashCode()))
-          .append(" [data=").append(getData())
-          .append(", description=").append(getDescription())
-          .append(", mqmd ccsid=").append(getMQMDCodedCharSetId())
-          .append(", properties=").append(getProperties())
-          .append(", qos=").append(getQOS())
-          .append(", reason=").append(getReason())
-          .append(", share=").append(getShare())
-          .append(", topic=").append(getTopic())
-          .append(", topic pattern=").append(getTopicPattern())
-          .append(", ttl=").append(getTtl())
-          .append(", type=").append(getType())
-          .append("]");
-        return sb.toString();
+        return getClass().getCanonicalName()
+                + "@" + Integer.toHexString(hashCode())
+                + " [data=" + getData()
+                + ", description=" + getDescription()
+                + ", mqmd ccsid=" + getMQMDCodedCharSetId()
+                + ", properties=" + getProperties()
+                + ", qos=" + getQOS()
+                + ", reason=" + getReason()
+                + ", share=" + getShare()
+                + ", topic=" + getTopic()
+                + ", topic pattern=" + getTopicPattern()
+                + ", ttl=" + getTtl()
+                + ", type=" + getType() + "]";
     }
 }

--- a/mqlight/src/main/java/com/ibm/mqlight/api/impl/NonBlockingFSMFactory.java
+++ b/mqlight/src/main/java/com/ibm/mqlight/api/impl/NonBlockingFSMFactory.java
@@ -455,7 +455,7 @@ class NonBlockingFSMFactory {
 
     private static void generateDotFile(OutputStream dotFile) {
         System.out.println("digraph G {");
-        final HashSet<String> invokedMethods = new HashSet<String>();
+        final HashSet<String> invokedMethods = new HashSet<>();
         InvocationHandler handler = new InvocationHandler() {
             @Override
             public Object invoke(Object proxy, Method method, Object[] args)
@@ -473,7 +473,7 @@ class NonBlockingFSMFactory {
             StateRepresentation<NonBlockingClientState, NonBlockingClientTrigger> rep = smConfig.getRepresentation(state);
 
             for (NonBlockingClientTrigger trigger : rep.getPermittedTriggers()) {
-                StateMachine<NonBlockingClientState, NonBlockingClientTrigger> sm = new StateMachine<NonBlockingClientState, NonBlockingClientTrigger>(rep.getUnderlyingState(), smConfig);
+                StateMachine<NonBlockingClientState, NonBlockingClientTrigger> sm = new StateMachine<>(rep.getUnderlyingState(), smConfig);
                 sm.fire(trigger);
                 System.out.print("\t" + rep.getUnderlyingState() + " -> " + sm.getState() + "[ label = \"" + trigger);
                 if (!invokedMethods.isEmpty()) {

--- a/mqlight/src/main/java/com/ibm/mqlight/api/impl/endpoint/BluemixEndpointService.java
+++ b/mqlight/src/main/java/com/ibm/mqlight/api/impl/endpoint/BluemixEndpointService.java
@@ -45,7 +45,7 @@ import com.ibm.mqlight.api.logging.LoggerFactory;
 
 public class BluemixEndpointService extends EndpointServiceImpl {
     private static final Logger logger = LoggerFactory.getLogger(BluemixEndpointService.class);
-      
+
     static {
         LogbackLogging.setup();
     }
@@ -67,7 +67,7 @@ public class BluemixEndpointService extends EndpointServiceImpl {
                     ")specified for System property com.ibm.mqlight.BluemixEndpointService.keepAliveSeconds (must be >= 0).");
         }
     }
-    
+
     private static ThreadPoolExecutor executor;
 
     private static class State {
@@ -89,8 +89,7 @@ public class BluemixEndpointService extends EndpointServiceImpl {
         }
         @Override
         public Thread newThread(Runnable runnable) {
-            Thread result = new Thread(group, runnable, "bluemix-endpoint-" + number.getAndIncrement());
-            return result;
+            return new Thread(group, runnable, "bluemix-endpoint-" + number.getAndIncrement());
         }
     }
 
@@ -105,7 +104,7 @@ public class BluemixEndpointService extends EndpointServiceImpl {
     protected String hitUri(String httpUri) throws IOException {
         final String methodName = "hitUri";
         logger.entry(this, methodName, httpUri);
-      
+
         URL url = new URL(httpUri);
         InputStream in = url.openStream();
         ByteArrayOutputStream out = new ByteArrayOutputStream();
@@ -115,18 +114,18 @@ public class BluemixEndpointService extends EndpointServiceImpl {
             if (amount < 0) break;
             out.write(buffer, 0, amount);
         }
-        
+
         final String result = out.toString("UTF-8");
-        
+
         logger.exit(this, methodName, result);
-        
+
         return result;
     }
 
     protected void doHttpLookup(final String httpUri, final EndpointPromise future) {
         final String methodName = "doHttpLookup";
         logger.entry(this, methodName, httpUri, future);
-      
+
         synchronized(this) {
             if (executor == null) {
                 executor = new ThreadPoolExecutor(THREAD_POOL_CORE_THREADS, THREAD_POOL_MAX_THREADS, THREAD_POOL_KEEP_ALIVE_SECONDS,
@@ -138,7 +137,7 @@ public class BluemixEndpointService extends EndpointServiceImpl {
             public void run() {
                 final String methodName = "run";
                 logger.entry(this, methodName);
-              
+
                 try {
                     String serviceJson = hitUri(httpUri);
 
@@ -180,25 +179,25 @@ public class BluemixEndpointService extends EndpointServiceImpl {
                     logger.data(this, methodName, exception);
                     future.setFailure(exception);
                 }
-                
+
                 logger.exit(this, methodName);
             }
         });
-        
+
         logger.exit(this, methodName);
     }
 
     protected void doRetry(EndpointPromise future) {
         final String methodName = "doRetry";
         logger.entry(this, methodName, future);
-      
+
         int retry;
         synchronized(state) {
             retry = state.retryCount;
             ++state.retryCount;
         }
         future.setWait(calculateDelay(retry));
-        
+
         logger.exit(this, methodName);
     }
 
@@ -206,9 +205,9 @@ public class BluemixEndpointService extends EndpointServiceImpl {
     public void lookup(EndpointPromise future) {
         final String methodName = "lookup";
         logger.entry(this, methodName, future);
-      
+
         try {
-            String lookupUri = null;
+            String lookupUri;
             Endpoint endpoint = null;
             boolean retry = false;
 
@@ -262,7 +261,7 @@ public class BluemixEndpointService extends EndpointServiceImpl {
             logger.data(this, methodName, exception);
             future.setFailure(exception);
         }
-        
+
         logger.exit(this, methodName);
     }
 
@@ -270,7 +269,7 @@ public class BluemixEndpointService extends EndpointServiceImpl {
     public void onSuccess(Endpoint endpoint) {
         final String methodName = "onSuccess";
         logger.entry(this, methodName, endpoint);
-      
+
         synchronized(state) {
             int index = -1;
             if (state.endpoints != null) {
@@ -286,7 +285,7 @@ public class BluemixEndpointService extends EndpointServiceImpl {
                 state.nextEndpointIndex = 0;
             }
         }
-        
+
         logger.exit(this, methodName);
     }
 

--- a/mqlight/src/main/java/com/ibm/mqlight/api/impl/endpoint/EndpointImpl.java
+++ b/mqlight/src/main/java/com/ibm/mqlight/api/impl/endpoint/EndpointImpl.java
@@ -68,7 +68,7 @@ class EndpointImpl implements Endpoint {
         }
         port = 5672;
         useSsl = false;
-        URI serviceUri = null;
+        URI serviceUri;
         try {
             serviceUri = new URI(uri);
             if (serviceUri.getScheme() == null) {

--- a/mqlight/src/main/java/com/ibm/mqlight/api/impl/engine/Engine.java
+++ b/mqlight/src/main/java/com/ibm/mqlight/api/impl/engine/Engine.java
@@ -86,7 +86,7 @@ import com.ibm.mqlight.api.timer.TimerService;
 public class Engine extends ComponentImpl implements Handler {
 
     private static final Logger logger = LoggerFactory.getLogger(Engine.class);
-    
+
     static class EngineProtocolTracer implements ProtocolTracer {
         private static final Logger logger = LoggerFactory.getLogger(EngineProtocolTracer.class);
 
@@ -161,7 +161,7 @@ public class Engine extends ComponentImpl implements Handler {
                 Sasl sasl = transport.sasl();
                 sasl.client();
                 if (or.endpoint.getUser() == null) {
-                    sasl.setMechanisms(new String[]{"ANONYMOUS"});
+                    sasl.setMechanisms("ANONYMOUS");
                 } else {
                     sasl.plain(or.endpoint.getUser(), or.endpoint.getPassword());
                 }
@@ -191,7 +191,7 @@ public class Engine extends ComponentImpl implements Handler {
             writeToNetwork(engineConnection);
         } else if (message instanceof SendRequest) {
             SendRequest sr = (SendRequest)message;
-       
+
             EngineConnection engineConnection = sr.connection;
 
             // Look to see if there is already a suitable sending link, and open one if there is not...
@@ -274,7 +274,7 @@ public class Engine extends ComponentImpl implements Handler {
                     linkReceiver.setSenderSettleMode(SenderSettleMode.SETTLED);
                     linkReceiver.setReceiverSettleMode(ReceiverSettleMode.FIRST);
                 }
-                
+
                 if (sr.topic.isShared()) {
                   source.setCapabilities(Symbol.valueOf("shared"));
                 }
@@ -310,7 +310,7 @@ public class Engine extends ComponentImpl implements Handler {
             DeliveryResponse dr = (DeliveryResponse)message;
             Delivery delivery = dr.request.delivery;
             delivery.settle();
-            
+
             EngineConnection engineConnection = (EngineConnection)dr.request.protonConnection.getContext();
             EngineConnection.SubscriptionData subData = engineConnection.subscriptionData.get(dr.request.topicPattern);
             if (subData == null) {
@@ -330,7 +330,7 @@ public class Engine extends ComponentImpl implements Handler {
             }
 
             writeToNetwork(engineConnection);
-            
+
             // send the DeliveryResponse back to indicate settlement has been actioned
             engineConnection.requestor.tell(message, this);
 
@@ -342,12 +342,12 @@ public class Engine extends ComponentImpl implements Handler {
             if (engineConnection != null) {
                 engineConnection.bytesWritten += wr.amount;
                 engineConnection.notifyInflightQos0(false);
-                
+
                 // If all buffered network data has been sent and the last send request could not be sent immediately
                 // then send a drain event to inform the client that it is ok to send more messages
                 if (wr.drained && !engineConnection.drained) {
                     engineConnection.drained = true;
-                    engineConnection.requestor.tell(new DrainNotification(), this); 
+                    engineConnection.requestor.tell(new DrainNotification(), this);
                 }
                 if (engineConnection.transport.pending() > 0) {
                     writeToNetwork(engineConnection);
@@ -566,12 +566,12 @@ public class Engine extends ComponentImpl implements Handler {
         ClientException result = null;
 
         if (errorCondition != null && errorCondition.getCondition() != null) {
-            if (errorCondition.getDescription().toString().contains("_Takeover")) {
+            if (errorCondition.getDescription().contains("_Takeover")) {
                 result = new ReplacedException(errorCondition.getDescription());
             } else if (errorCondition.getCondition().equals(AmqpError.PRECONDITION_FAILED)
                     || errorCondition.getCondition().equals(AmqpError.NOT_ALLOWED)
                     || errorCondition.getCondition().equals(AmqpError.NOT_IMPLEMENTED)
-                    || errorCondition.getDescription().toString().contains("_InvalidSourceTimeout")) {
+                    || errorCondition.getDescription().contains("_InvalidSourceTimeout")) {
                 result = new NotPermittedException(errorCondition.getDescription());
             }
 
@@ -845,7 +845,7 @@ public class Engine extends ComponentImpl implements Handler {
               } else {
                   exception = new Exception(error.getDescription());
               }
-          } else if (delivery.getRemoteState() instanceof Released) {;
+          } else if (delivery.getRemoteState() instanceof Released) {
               exception = new Exception("Message was released");
           } else if (delivery.getRemoteState() instanceof Modified) {
               exception = new Exception("Message was modified");

--- a/mqlight/src/main/java/com/ibm/mqlight/api/impl/logging/FFDC.java
+++ b/mqlight/src/main/java/com/ibm/mqlight/api/impl/logging/FFDC.java
@@ -32,13 +32,13 @@ class FFDC {
 
   /** Character sequence to use as the line separator */
   private static final String lineSeparator = System.getProperty("line.separator");
-  
+
   /**
    * Captures FFDC information.
-   * 
+   *
    * @param logger Logger for identifying caller, and for outputting FFDC information to.
    * @param methodName Name of the calling method.
-   * @param probeId A probe identifier that can be used to uniquely identify the point in the code that requested the data capture. The probe identifier should be unique within a
+   * @param probe A probe identifier that can be used to uniquely identify the point in the code that requested the data capture. The probe identifier should be unique within a
    *          class.
    * @param throwable The throwable that triggered capturing of FFDC information. This can be null if there is no obvious throwable cause.
    * @param data Arbitrary data that is captured into the FFDC record.
@@ -49,7 +49,7 @@ class FFDC {
 
   /**
    * Captures FFDC information.
-   * 
+   *
    * @param logger Logger for identifying caller, and for outputting FFDC information to.
    * @param callingObject Object requesting the FFDC.
    * @param methodName Name of the calling method.
@@ -62,16 +62,16 @@ class FFDC {
     long ffdcTimestamp = System.currentTimeMillis();
     final String className = logger.getName();
     final StringBuilder sb = new StringBuilder();
-    
+
     sb.append("Level:      ");
     sb.append(Version.getVersion());
     sb.append(lineSeparator);
-    
+
     final SimpleDateFormat recordFormatter = new SimpleDateFormat("dd/MM/yyyy HH:mm:ss:SSS z");
     sb.append("Time:       ");
     sb.append(recordFormatter.format(ffdcTimestamp));
     sb.append(lineSeparator);
-            
+
     Thread currentThread = Thread.currentThread();
     sb.append("Thread:     ");
     sb.append(currentThread.getId());
@@ -79,33 +79,33 @@ class FFDC {
     sb.append(currentThread.getName());
     sb.append(")");
     sb.append(lineSeparator);
-            
+
     if (className != null) {
       sb.append("Class:      ");
       sb.append(className);
       sb.append(lineSeparator);
     }
-            
+
     if (callingObject != null) {
       sb.append("Instance:   ");
       sb.append(Integer.toHexString(System.identityHashCode(callingObject)));
       sb.append(lineSeparator);
     }
-            
+
     if (methodName != null) {
       sb.append("Method:     ");
       sb.append(methodName);
       sb.append(lineSeparator);
     }
-            
+
     sb.append("Probe:      ");
     sb.append(probeId == null ? "null" : probeId);
     sb.append(lineSeparator);
-    
+
     sb.append("Cause:      ");
     sb.append(throwable == null ? "null" : throwable.toString());
     sb.append(lineSeparator);
-    
+
     try {
       ByteArrayOutputStream byteOut = new ByteArrayOutputStream();
       PrintStream stream = new PrintStream(byteOut, false, "UTF-8");
@@ -121,7 +121,7 @@ class FFDC {
     } catch (UnsupportedEncodingException e) {
       logger.error("Failed to generate FFDC call stack. Reason: ", e.getLocalizedMessage());
     }
-    
+
     if (data != null) {
       for (int i = 0; i < data.length; ++i) {
         Object item = data[i];
@@ -132,13 +132,13 @@ class FFDC {
         sb.append(lineSeparator);
       }
     }
-    
+
     for (Thread thread : Thread.getAllStackTraces().keySet()) {
       sb.append(getThreadInfo(thread));
     }
-        
+
     logger.error(LogMarker.FFDC.getValue(), sb.toString());
-    
+
     // Additionally output a javacore (to capture the full information to file)
     try {
       final String javacoreFilePath = Javacore.generateJavaCore();
@@ -150,7 +150,7 @@ class FFDC {
 
   /**
    * Gets and formats the specified thread's information.
-   * 
+   *
    * @param thread The thread to obtain the information from.
    * @return A formatted string for the thread information.
    */
@@ -182,7 +182,7 @@ class FFDC {
           sb.append(":");
           sb.append(element.getLineNumber());
         } else {
-          sb.append(element.getFileName());        
+          sb.append(element.getFileName());
         }
         sb.append(")");
         sb.append(lineSeparator);
@@ -193,5 +193,5 @@ class FFDC {
     return sb.toString();
   }
 
-  
+
 }

--- a/mqlight/src/main/java/com/ibm/mqlight/api/impl/logging/Javacore.java
+++ b/mqlight/src/main/java/com/ibm/mqlight/api/impl/logging/Javacore.java
@@ -43,7 +43,7 @@ class Javacore {
   /** The directory where javacore files are expected to be generated. */
   private static String javacoreDirectoryPath;
   static {
-    
+
     // Determine if an alternative javcore directory is configured. Only applicable to IBM JREs.
     // Note z/OS currently not supported by MQ Light, but check included here for completeness
     final String alternativeJavacoreDirectoryPath;
@@ -71,7 +71,7 @@ class Javacore {
     // Set up the methods to use for taking javacores
     try {
       final Class<?> dumpClass = Class.forName("com.ibm.jvm.Dump");
-      javaDumpMethod = dumpClass.getMethod("JavaDump", new Class<?>[0]);
+      javaDumpMethod = dumpClass.getMethod("JavaDump");
     } catch (final Exception exception) {
       // No FFDC required - we might not be running on a JVM which
       // supports the IBM JavaDump classes.
@@ -81,7 +81,7 @@ class Javacore {
 
   /**
    * Public method that allows the caller to ask that a javacore be generated.
-   * 
+   *
    * @return The file path for the generated java core file.
    * @throws Throwable
    */
@@ -103,7 +103,7 @@ class Javacore {
 
   /**
    * Causes an JVM with the IBM com.ibm.jvm.Dump class present to take a java core.
-   * 
+   *
    * @return The file path for the generated java core file.
    * @throws Throwable
    */
@@ -112,10 +112,9 @@ class Javacore {
 
     String filePath;
     try {
-      javaDumpMethod.invoke(null, new Object[0]);
+      javaDumpMethod.invoke(null);
 
-      final File currentJavacoreFile = getLatestJavacoreFile();
-      File javacoreFile = currentJavacoreFile;
+      File javacoreFile = getLatestJavacoreFile();
       filePath = javacoreFile.getAbsolutePath();
 
     } catch (final InvocationTargetException invocationException) {
@@ -158,7 +157,7 @@ class Javacore {
 
     final File result = new File(javacoreDirectory, requiredJavacoreFilePath);
 
-    logger.exit("getLatestJavacoreFilePath", (Object) result);
+    logger.exit("getLatestJavacoreFilePath", result);
 
     return result;
   }
@@ -166,7 +165,7 @@ class Javacore {
   /**
    * Simulates a java core, for use with JVMs which do not have the com.ibm.jvm.Dump class available. The file is given a name which looks like a java core to avoid introducing new
    * 'must gathers' for service.
-   * 
+   *
    * @return The file path for the generated java core file.
    */
   private static String simulateJavaCore() {
@@ -198,17 +197,35 @@ class Javacore {
 
       // Generate a thread description in a java core like style.
       final Thread thread = entry.getKey();
-      sb.append("\"" + thread.getName() + "\" ");
-      sb.append("(id: " + thread.getId() + ", state: " + thread.getState() + ") ");
-      sb.append("priority=" + thread.getPriority() + ", interrupted=" + thread.isInterrupted() + ", daemon=" + thread.isDaemon());
+      sb.append("\"");
+      sb.append(thread.getName());
+      sb.append("\" ");
+      sb.append("(id: ");
+      sb.append(thread.getId());
+      sb.append(", state: ");
+      sb.append(thread.getState());
+      sb.append(") ");
+      sb.append("priority=");
+      sb.append(thread.getPriority());
+      sb.append(", interrupted=");
+      sb.append(thread.isInterrupted());
+      sb.append(", daemon=");
+      sb.append(thread.isDaemon());
       sb.append(endOfLineCharacter);
 
       // Dump the stack in a java core like style
       for (final StackTraceElement element : entry.getValue()) {
-        sb.append("   at " + element.getClassName() + "." + element.getMethodName());
+        sb.append("   at ");
+        sb.append(element.getClassName());
+        sb.append(".");
+        sb.append(element.getMethodName());
         if (element.isNativeMethod()) sb.append("(Native Method)");
         else {
-          sb.append("(" + element.getFileName() + ":" + element.getLineNumber() + ")");
+          sb.append("(");
+          sb.append(element.getFileName());
+          sb.append(":");
+          sb.append(element.getLineNumber());
+          sb.append(")");
         }
         sb.append(endOfLineCharacter);
       }

--- a/mqlight/src/main/java/com/ibm/mqlight/api/impl/logging/LogMarker.java
+++ b/mqlight/src/main/java/com/ibm/mqlight/api/impl/logging/LogMarker.java
@@ -34,13 +34,13 @@ public enum LogMarker {
   EXIT           ("exit"),
   DATA           ("data"),
   THROWING       ("throwing");
-  
+
   private final Marker marker;
-  
-  private LogMarker(String markerLabel) {
+
+  LogMarker(String markerLabel) {
     marker = MarkerFactory.getMarker(markerLabel);
   }
-  
+
   public Marker getValue() {
     return marker;
   }

--- a/mqlight/src/main/java/com/ibm/mqlight/api/impl/logging/LoggerFactoryImpl.java
+++ b/mqlight/src/main/java/com/ibm/mqlight/api/impl/logging/LoggerFactoryImpl.java
@@ -19,7 +19,6 @@
 
 package com.ibm.mqlight.api.impl.logging;
 
-import com.ibm.mqlight.api.impl.logging.LoggerImpl;
 import com.ibm.mqlight.api.logging.Logger;
 import com.ibm.mqlight.api.logging.LoggerFactory;
 
@@ -27,10 +26,10 @@ import com.ibm.mqlight.api.logging.LoggerFactory;
  * Factory implementation to obtain a {@link Logger} implementation.
  */
 class LoggerFactoryImpl extends LoggerFactory {
-  
+
   /**
    * Obtains a {@link Logger} implementation for the specified class.
-   *  
+   *
    * @param clazz Class to be associated with the logger instance.
    * @return {@link Logger} instance for trace and information logging.
    */

--- a/mqlight/src/main/java/com/ibm/mqlight/api/impl/logging/LoggerImpl.java
+++ b/mqlight/src/main/java/com/ibm/mqlight/api/impl/logging/LoggerImpl.java
@@ -28,19 +28,19 @@ import com.ibm.mqlight.api.logging.Logger;
 /**
  * A trace/logger implementation that utilizes a SLF4J logger.
  * <p>
- * SLF4J loggers do not have methods to directly trace method entry, exit and exception throwing. But a {@link Marker} can be passed to various methods. Thus we use {@link Maker}s
+ * SLF4J loggers do not have methods to directly trace method entry, exit and exception throwing. But a {@link Marker} can be passed to various methods. Thus we use {@link Marker}s
  * to "mark" calls as entry, exit, throw, etc. It will then be up to the logger to filter and display appropriately based on these markers.
  */
 class LoggerImpl implements Logger {
-  
+
   /**
    * The underlying SLFJ logger.
    */
   private final org.slf4j.Logger logger;
-  
+
   /**
    * Constructor.
-   * 
+   *
    * @param clazz The class associated with this logger instance.
    */
   public LoggerImpl(Class<?> clazz) {
@@ -49,52 +49,51 @@ class LoggerImpl implements Logger {
 
   /**
    * Constructor, from an existing {@link org.slf4j.Logger}.
-   * 
+   *
    * @param logger The SLF4J logger instance.
    */
   public LoggerImpl(org.slf4j.Logger logger) {
     this.logger = logger;
   }
-  
+
   @Override
   public void setClientId(String clientId) {
     MDC.put(CLIENTID_KEY, clientId);
   }
 
-  
+
   @Override
   public void info(String message) {
     logger.info(LogMarker.INFO.getValue(), message);
   }
-  
+
   @Override
   public void warning(String message) {
     logger.warn(LogMarker.WARNING.getValue(), message);
   }
-  
+
   @Override
   public void error(String message) {
     logger.error(LogMarker.ERROR.getValue(), message);
   }
-  
+
   @Override
   public void error(String message, Throwable throwable) {
     logger.error(LogMarker.ERROR.getValue(), message, throwable);
   }
-  
-  
+
+
   @Override
   public void entry(String methodName) {
     logger.trace(LogMarker.ENTRY.getValue(), methodName, (Object)null);
   }
-  
+
   @Override
   public void entry(String methodName, Object... objects) {
     if (logger.isTraceEnabled()) {
       final Object[] objs = new Object[objects.length + 1];
       objs[0] = null;
-      for (int i = 0; i < objects.length; i++)
-        objs[i + 1] = objects[i];
+      System.arraycopy(objects, 0, objs, 1, objects.length);
       logger.trace(LogMarker.ENTRY.getValue(), methodName, objs);
     }
   }
@@ -109,8 +108,7 @@ class LoggerImpl implements Logger {
     if (logger.isTraceEnabled()) {
       final Object[] objs = new Object[objects.length + 1];
       objs[0] = source;
-      for (int i = 0; i < objects.length; i++)
-        objs[i + 1] = objects[i];
+      System.arraycopy(objects, 0, objs, 1, objects.length);
       logger.trace(LogMarker.ENTRY.getValue(), methodName, objs);
     }
   }
@@ -135,7 +133,7 @@ class LoggerImpl implements Logger {
     logger.trace(LogMarker.EXIT.getValue(), methodName, source, result);
   }
 
-  
+
   @Override
   public void data(String methodName) {
     logger.trace(LogMarker.DATA.getValue(), methodName, (Object)null);
@@ -146,8 +144,7 @@ class LoggerImpl implements Logger {
     if (logger.isTraceEnabled()) {
       final Object[] objs = new Object[objects.length + 1];
       objs[0] = null;
-      for (int i = 0; i < objects.length; i++)
-        objs[i + 1] = objects[i];
+      System.arraycopy(objects, 0, objs, 1, objects.length);
       logger.trace(LogMarker.DATA.getValue(), methodName, objs);
     }
   }
@@ -156,14 +153,13 @@ class LoggerImpl implements Logger {
   public void data(Object source, String methodName) {
     logger.trace(LogMarker.DATA.getValue(), methodName, source);
   }
-  
+
   @Override
   public void data(Object source, String methodName, Object... objects) {
     if (logger.isTraceEnabled()) {
       final Object[] objs = new Object[objects.length + 1];
       objs[0] = source;
-      for (int i = 0; i < objects.length; i++)
-        objs[i + 1] = objects[i];
+      System.arraycopy(objects, 0, objs, 1, objects.length);
       logger.trace(LogMarker.DATA.getValue(), methodName, objs);
     }
   }

--- a/mqlight/src/main/java/com/ibm/mqlight/api/impl/logging/logback/ArgsConverter.java
+++ b/mqlight/src/main/java/com/ibm/mqlight/api/impl/logging/logback/ArgsConverter.java
@@ -31,13 +31,13 @@ import com.ibm.mqlight.api.impl.logging.LogMarker;
  * A logback converter to support a method arguments customer conversion specifier.
  * <p>
  * By default only the first 1024 bytes of an argument will be written out. This can be changed by defining environment varaible
- * MQLIGHT_JAVA_LOG_TRACE_ARG_MAX_BYTES, to specify a different value. 
+ * MQLIGHT_JAVA_LOG_TRACE_ARG_MAX_BYTES, to specify a different value.
  * <p>
  * Note that this assumes that whenever the event has one of the trace markers (defined in {@link TraceFilter}) then the first argument for the event specifies the object id, so
  * this is skipped over.
  */
 public class ArgsConverter extends ClassicConverter {
-  
+
   /**
    * Default the maximum length of an argument written to the log to 1024 bytes, allowing an environment variable to
    * be set to specify a different value.
@@ -51,20 +51,16 @@ public class ArgsConverter extends ClassicConverter {
       try {
         max = Integer.parseInt(maxArgLengthStr);
         if (max < 0) {
-           final ClientRuntimeException exception =
-               new ClientRuntimeException("Invalid "+ARG_MAX_BYTES_ENVVAR+" setting. Value must be a positive integer.");
-          throw exception;
+           throw new ClientRuntimeException("Invalid "+ARG_MAX_BYTES_ENVVAR+" setting. Value must be a positive integer.");
         }
       } catch(NumberFormatException e) {
-        final ClientRuntimeException exception =
-              new ClientRuntimeException("Invalid "+ARG_MAX_BYTES_ENVVAR+" setting. Value must be a positive integer.");
-        throw exception;
+        throw new ClientRuntimeException("Invalid "+ARG_MAX_BYTES_ENVVAR+" setting. Value must be a positive integer.");
       }
     }
-      
+
     MAX_ARG_LENGTH = max;
   }
-    
+
   @Override
   public String convert(ILoggingEvent event) {
     final Marker marker = event.getMarker();
@@ -77,13 +73,17 @@ public class ArgsConverter extends ClassicConverter {
           sb.append(" returns");
           String arg = args[offset] == null ? null : args[offset].toString();
           if (arg != null && arg.length() > MAX_ARG_LENGTH) arg = arg.substring(0,  MAX_ARG_LENGTH)+"...";
-          sb.append(" [" + arg + "]");
+          sb.append(" [");
+          sb.append(arg);
+          sb.append("]");
         }
       } else {
         for (int i = offset; i < args.length; i++) {
           String arg = args[i] == null ? null : args[i].toString();
           if (arg != null && arg.length() > MAX_ARG_LENGTH) arg = arg.substring(0,  MAX_ARG_LENGTH)+"...";
-          sb.append(" [" + arg + "]");
+          sb.append(" [");
+          sb.append(arg);
+          sb.append("]");
         }
       }
     }

--- a/mqlight/src/main/java/com/ibm/mqlight/api/impl/logging/logback/IndentConverter.java
+++ b/mqlight/src/main/java/com/ibm/mqlight/api/impl/logging/logback/IndentConverter.java
@@ -39,8 +39,8 @@ import ch.qos.logback.classic.spi.ILoggingEvent;
  * required anyway, hence indentation is not required by the service team.
  */
 public class IndentConverter extends ClassicConverter {
-  
-  private static Map<Marker, String> markerMap = new HashMap<Marker, String>();
+
+  private static Map<Marker, String> markerMap = new HashMap<>();
   static {
     markerMap.put(LogMarker.INFO.getValue(),     "i");
     markerMap.put(LogMarker.WARNING.getValue(),  "w");
@@ -52,7 +52,7 @@ public class IndentConverter extends ClassicConverter {
     markerMap.put(LogMarker.DATA.getValue(),     "d");
     markerMap.put(LogMarker.THROWING.getValue(), "!");
   }
-  
+
   @Override
   public String convert(ILoggingEvent event) {
     final Marker marker = event.getMarker();

--- a/mqlight/src/main/java/com/ibm/mqlight/api/impl/logging/logback/LevelConverter.java
+++ b/mqlight/src/main/java/com/ibm/mqlight/api/impl/logging/logback/LevelConverter.java
@@ -30,12 +30,11 @@ import ch.qos.logback.classic.spi.ILoggingEvent;
  * When a passed event contains a matrker, the {@link #convert(ILoggingEvent)} method simply returns a {@link String} with text for the marker, otherwise the a {@link String} for the event's level is returned.
  */
 public class LevelConverter extends ClassicConverter {
-  
+
   @Override
   public String convert(ILoggingEvent event) {
     final Marker marker = event.getMarker();
-    final String result = marker == null ? (event.getLevel() == null ? "" : event.getLevel().toString()) : marker.getName();
-    return result;
+    return marker == null ? (event.getLevel() == null ? "" : event.getLevel().toString()) : marker.getName();
   }
 
 }

--- a/mqlight/src/main/java/com/ibm/mqlight/api/impl/logging/logback/TraceFilter.java
+++ b/mqlight/src/main/java/com/ibm/mqlight/api/impl/logging/logback/TraceFilter.java
@@ -31,18 +31,18 @@ import ch.qos.logback.core.filter.Filter;
 import ch.qos.logback.core.spi.FilterReply;
 
 /**
- * A logback filter for selecting MQ Light trace type events. These are events that have been marked as entry, exit, data or throwing. 
+ * A logback filter for selecting MQ Light trace type events. These are events that have been marked as entry, exit, data or throwing.
  */
 public class TraceFilter extends Filter<ILoggingEvent> {
 
-  static Map<Marker, String> traceMarkerMap = new HashMap<Marker, String>();
+  static Map<Marker, String> traceMarkerMap = new HashMap<>();
   static {
     traceMarkerMap.put(LogMarker.ENTRY.getValue(), "{");
     traceMarkerMap.put(LogMarker.EXIT.getValue(), "}");
     traceMarkerMap.put(LogMarker.DATA.getValue(), "d");
     traceMarkerMap.put(LogMarker.THROWING.getValue(), "!");
   }
-  
+
   @Override
   public FilterReply decide(ILoggingEvent event) {
     if (traceMarkerMap.containsKey(event.getMarker())) {

--- a/mqlight/src/main/java/com/ibm/mqlight/api/impl/timer/TimerServiceImpl.java
+++ b/mqlight/src/main/java/com/ibm/mqlight/api/impl/timer/TimerServiceImpl.java
@@ -37,7 +37,7 @@ public class TimerServiceImpl implements TimerService {
     private static final int idleKeepAliveTimeMs = 500;
     private static final ScheduledThreadPoolExecutor executor;
     private int timerCount = 0;
-    
+
     static class TimerServiceThreadFactory implements ThreadFactory {
       final ThreadFactory factory = Executors.defaultThreadFactory();
       @Override
@@ -67,7 +67,7 @@ public class TimerServiceImpl implements TimerService {
         private ScheduledFuture<?> future;
 
         private Timer(TimerServiceImpl service,
-                      Promise<Void> promise, 
+                      Promise<Void> promise,
                       ConcurrentHashMap<Promise<Void>, Timer> promiseToTimer) {
             final String methodName = "<init>";
             logger.entry(this, methodName, service, promise, promiseToTimer);
@@ -98,8 +98,7 @@ public class TimerServiceImpl implements TimerService {
 
         final Timer timer = new Timer(this, promise, promiseToTimer);
         incrementUsage();
-        final ScheduledFuture<?> sf = executor.schedule(timer, delay, TimeUnit.MILLISECONDS);
-        timer.future = sf;
+        timer.future = executor.schedule(timer, delay, TimeUnit.MILLISECONDS);
         promiseToTimer.put(promise, timer);
 
         logger.exit(this, methodName);
@@ -127,7 +126,7 @@ public class TimerServiceImpl implements TimerService {
             executor.setKeepAliveTime(idleKeepAliveTimeMs, TimeUnit.MILLISECONDS);
         }
     }
-    
+
     private synchronized void incrementUsage() {
         if (++timerCount == 1) {
             executor.setKeepAliveTime(Long.MAX_VALUE, TimeUnit.NANOSECONDS);

--- a/mqlight/src/main/java/com/ibm/mqlight/api/logging/FFDCProbeId.java
+++ b/mqlight/src/main/java/com/ibm/mqlight/api/logging/FFDCProbeId.java
@@ -74,11 +74,11 @@ public enum FFDCProbeId {
   PROBE_049("FFDC_049");
 
   private final String id;
-  
-  private FFDCProbeId(String id) {
+
+  FFDCProbeId(String id) {
     this.id = id;
   }
-  
+
   public String toString() {
     return id;
   }

--- a/mqlight/src/main/java/com/ibm/mqlight/api/logging/Logger.java
+++ b/mqlight/src/main/java/com/ibm/mqlight/api/logging/Logger.java
@@ -31,179 +31,179 @@ package com.ibm.mqlight.api.logging;
  * unnecessary conversion when trace is off (note that with this approach there is no need to use a {@code if (Trace.enabled()))} type test when invoking the trace methods).
  */
 public interface Logger {
-  
-  
+
+
   /** The client id key, which can be used to record the client id by implementations of the {@link #setClientId(String)} method. */
-  public static final String CLIENTID_KEY = "clientid";
-  
+  String CLIENTID_KEY = "clientid";
+
   /**
    * Associate the specified client id for the current thread, and its child threads, for tracing and logging
-   * 
+   *
    * @param clientId
    */
-  public abstract void setClientId(String clientId);
-  
+  void setClientId(String clientId);
+
 
   /**
    * Logs an information message.
-   * 
+   *
    * @param message The information message text.
    */
-  public abstract void info(String message);
-  
+  void info(String message);
+
   /**
    * Logs a warning.
-   * 
+   *
    * @param message The warning message text.
    */
-  public abstract void warning(String message);
-  
+  void warning(String message);
+
   /**
    * Logs an error message.
-   * 
+   *
    * @param message The error message text.
    */
-  public abstract void error(String message);
-  
+  void error(String message);
+
   /**
    * Logs an error message.
-   * 
+   *
    * @param message The error message text.
    * @param throwable The exception causing the error.
    */
-  public abstract void error(String message, Throwable throwable);
-  
-  
+  void error(String message, Throwable throwable);
+
+
   /**
    * Method entry tracing for static classes.
-   * 
+   *
    * @param methodName Name of the calling method.
    */
-  public abstract void entry(String methodName);
-  
+  void entry(String methodName);
+
   /**
    * Method entry tracing for static classes. Note that this may not be that efficient.
-   * 
+   *
    * @param methodName Name of the calling method.
    * @param objects Objects on which toString() is called.
    */
-  public abstract void entry(String methodName, Object... objects);
+  void entry(String methodName, Object... objects);
 
   /**
    * Method entry tracing.
-   * 
+   *
    * @param source Object making the trace call.
    * @param methodName Name of the calling method.
    */
-  public abstract void entry(Object source, String methodName);
-    
+  void entry(Object source, String methodName);
+
   /**
    * Method entry tracing. Note that this may not be that efficient.
-   * 
+   *
    * @param source Object making the trace call.
    * @param methodName Name of the calling method.
    * @param objects Objects on which toString() is called.
    */
-  public abstract void entry(Object source, String methodName, Object... objects);
-  
-  
-  /**
-   * Method exit tracing for static classes.
-   * 
-   * @param methodName Name of the calling method.
-   */
-  public abstract void exit(String methodName);
+  void entry(Object source, String methodName, Object... objects);
+
 
   /**
    * Method exit tracing for static classes.
-   * 
+   *
+   * @param methodName Name of the calling method.
+   */
+  void exit(String methodName);
+
+  /**
+   * Method exit tracing for static classes.
+   *
    * @param methodName Name of the calling method.
    * @param result Object on which toString() is called, containing the return value.
    */
-  public abstract void exit(String methodName, Object result);
+  void exit(String methodName, Object result);
 
   /**
    * Method exit tracing.
-   * 
+   *
    * @param source Object making the trace call.
    * @param methodName Name of the calling method.
    */
-  public abstract void exit(Object source, String methodName);
+  void exit(Object source, String methodName);
 
   /**
    * Method exit tracing.
-   * 
+   *
    * @param source Object making the trace call.
    * @param methodName Name of the calling method.
    * @param result Object on which toString() is called, containing the return value.
    */
-  public abstract void exit(Object source, String methodName, Object result);
-  
-  
+  void exit(Object source, String methodName, Object result);
+
+
   /**
    * Method data tracing for static classes.
-   * 
+   *
    * @param methodName Name of the calling method.
    */
-  public abstract void data(String methodName);
+  void data(String methodName);
 
   /**
    * Method data tracing for static classes. Note that this may not be that efficient.
-   * 
+   *
    * @param methodName Name of the calling method.
    * @param objects Objects on which toString() is called.
    */
-  public abstract void data(String methodName, Object... objects);
+  void data(String methodName, Object... objects);
 
   /**
    * Method data tracing.
-   * 
+   *
    * @param source Object making the trace call.
    * @param methodName Name of the calling method.
    */
-  public abstract void data(Object source, String methodName);
-  
+  void data(Object source, String methodName);
+
   /**
    * Method data tracing. Note that this may not be that efficient.
-   * 
+   *
    * @param source Object making the trace call.
    * @param methodName Name of the calling method.
    * @param objects Objects on which toString() is called.
    */
-  public abstract void data(Object source, String methodName, Object... objects);
-  
-  
+  void data(Object source, String methodName, Object... objects);
+
+
   /**
    * Exception tracing when a throwable is caught in a static class.
-   * 
+   *
    * @param methodName Name of the calling method.
    * @param throwable Causing the event.
    */
-  public abstract void throwing(String methodName, Throwable throwable);
+  void throwing(String methodName, Throwable throwable);
 
   /**
    * Exception tracing.
-   * 
+   *
    * @param source Object making the trace call.
    * @param methodName Name of the calling method.
    * @param throwable Causing the event.
    */
-  public abstract void throwing(Object source, String methodName, Throwable throwable);
+  void throwing(Object source, String methodName, Throwable throwable);
 
   /**
    * Captures FFDC information.
-   * 
+   *
    * @param methodName Name of the calling method.
    * @param probeId A probe identifier that can be used to uniquely identify the point in the code that requested the data capture. The probe identifier should be unique within a
    *          class.
    * @param throwable The throwable that triggered capturing of FFDC information. This can be null if there is no obvious throwable cause.
    * @param data Arbitrary data that is captured into the FFDC record.
    */
-  public abstract void ffdc(String methodName, FFDCProbeId probeId, Throwable throwable, Object... data);
+  void ffdc(String methodName, FFDCProbeId probeId, Throwable throwable, Object... data);
 
   /**
    * Captures FFDC information.
-   * 
+   *
    * @param source Object requesting the FFDC.
    * @param methodName Name of the calling method.
    * @param probeId A probe identifier that can be used to uniquely identify the point in the code that requested the data capture. The probe identifier should be unique within a
@@ -211,6 +211,6 @@ public interface Logger {
    * @param throwable The throwable that triggered capturing of FFDC information. This can be null if there is no obvious throwable cause.
    * @param data Arbitrary data that is captured into the FFDC record.
    */
-  public abstract void ffdc(Object source, String methodName, FFDCProbeId probeId, Throwable throwable, Object... data);
+  void ffdc(Object source, String methodName, FFDCProbeId probeId, Throwable throwable, Object... data);
 }
 

--- a/mqlight/src/main/java/com/ibm/mqlight/api/logging/LoggerFactory.java
+++ b/mqlight/src/main/java/com/ibm/mqlight/api/logging/LoggerFactory.java
@@ -25,61 +25,61 @@ import java.lang.reflect.Constructor;
  * Factory to obtain a {@link Logger} implementation.
  */
 public abstract class LoggerFactory {
-  
+
   public static final String LOGGER_FACTORY_IMPL_CLASS_NAME= "com.ibm.mqlight.api.impl.logging.LoggerFactoryImpl";
-  
+
   /** Implementation of a {@link LoggerFactory} */
   private static final LoggerFactory impl;
   static {
     LoggerFactory loggerFactoryImpl;
     try {
       Class<?> classToInstantiate = Class.forName(LOGGER_FACTORY_IMPL_CLASS_NAME);
-      Constructor<?> constructor = classToInstantiate.getDeclaredConstructor(new Class[] {});
+      Constructor<?> constructor = classToInstantiate.getDeclaredConstructor();
       constructor.setAccessible(true);
-      loggerFactoryImpl = (LoggerFactory) constructor.newInstance(new Object[] {});
-    
+      loggerFactoryImpl = (LoggerFactory) constructor.newInstance();
+
     } catch (Exception exception) {
       // No FFDC Code Needed.
-      // We may not have any FFDC instantiated so simply print the stack. 
+      // We may not have any FFDC instantiated so simply print the stack.
       exception.printStackTrace();
       // Assume we have no chained exception support.
       throw new Error(exception.toString());
     }
-  
+
     impl = loggerFactoryImpl;
   }
-  
+
   /**
    * Obtains a {@link Logger} implementation for the specified class.
-   *  
+   *
    * @param clazz Class to be associated with the logger instance.
    * @return {@link Logger} instance for trace and information logging.
    */
   public static Logger getLogger(Class<?> clazz) {
     return impl.getLoggerImpl(clazz);
   }
-  
+
   /**
    * Obtains a {@link Logger} implementation for the specified {@link org.slf4j.Logger}.
-   *  
+   *
    * @param logger The {@link org.slf4j.Logger} to be associated with the logger instance.
    * @return {@link Logger} instance for trace and information logging.
    */
   public static Logger getLogger(org.slf4j.Logger logger) {
     return impl.getLoggerImpl(logger);
   }
-  
+
   /**
    * Internal method to obtain the {@link Logger} implementation from the static {@link LoggerFactory} implementation.
-   * 
+   *
    * @param clazz Class to be associated with the logger instance.
    * @return {@link Logger} instance for trace and information logging.
    */
   protected abstract Logger getLoggerImpl(Class<?> clazz);
-  
+
   /**
    * Internal method to obtain the {@link Logger} implementation from the static {@link LoggerFactory} implementation.
-   * 
+   *
    * @param logger The SLF4J logger instance.
    * @return {@link Logger} instance for trace and information logging.
    */

--- a/mqlight/src/main/java/com/ibm/mqlight/api/network/NetworkChannel.java
+++ b/mqlight/src/main/java/com/ibm/mqlight/api/network/NetworkChannel.java
@@ -32,24 +32,24 @@ public interface NetworkChannel {
      * @param promise a promise which is to be completed when the connection is closed.
      */
     void close(Promise<Void> promise);
-    
+
     /**
      * Write data to the network connection.
      * @param buffer contains the data to write.
      * @param promise a promise which is to be completed when the data is written.
      */
     void write(ByteBuffer buffer, Promise<Boolean> promise);
-    
+
     /**
      * Allows an arbitrary object to be associated with this channel object.
      * @param context
      */
-    public void setContext(Object context);
-    
+    void setContext(Object context);
+
     /**
      * Retrieves the value set using {@link NetworkChannel#setContext(Object)}.
      * Returns <code>null</code> if no value has yet been set.
      * @return the context object (if any) set using {@link NetworkChannel#setContext(Object)}
      */
-    public Object getContext();
+    Object getContext();
 }

--- a/mqlight/src/main/java/com/ibm/mqlight/api/network/NetworkService.java
+++ b/mqlight/src/main/java/com/ibm/mqlight/api/network/NetworkService.java
@@ -42,5 +42,5 @@ public interface NetworkService {
      *                {@link Promise#setSuccess(Object)} is passed an implementation of
      *                {@link NetworkChannel} that can be used to send data over the network connection.
      */
-    public void connect(Endpoint endpoint, NetworkListener listener, Promise<NetworkChannel> promise);
+    void connect(Endpoint endpoint, NetworkListener listener, Promise<NetworkChannel> promise);
 }

--- a/mqlight/src/main/java/com/ibm/mqlight/api/timer/TimerService.java
+++ b/mqlight/src/main/java/com/ibm/mqlight/api/timer/TimerService.java
@@ -41,7 +41,7 @@ public interface TimerService {
      * @param delay a delay in milliseconds
      * @param promise a promise object to be completed after the delay period
      */
-    public void schedule(long delay, Promise<Void> promise);
+    void schedule(long delay, Promise<Void> promise);
 
     /**
      * Cancels a previously scheduled promise (e.g. one that has previously been passed to
@@ -58,5 +58,5 @@ public interface TimerService {
      *
      * @param promise the promise to cancel
      */
-    public void cancel(Promise<Void> promise);
+    void cancel(Promise<Void> promise);
 }

--- a/mqlight/src/test/java/com/ibm/mqlight/api/impl/TestNonBlockingClientImpl.java
+++ b/mqlight/src/test/java/com/ibm/mqlight/api/impl/TestNonBlockingClientImpl.java
@@ -39,8 +39,6 @@ import java.util.Queue;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 
-import junit.framework.AssertionFailedError;
-
 import org.apache.qpid.proton.Proton;
 import org.apache.qpid.proton.amqp.Binary;
 import org.apache.qpid.proton.amqp.messaging.AmqpValue;
@@ -83,6 +81,7 @@ import com.ibm.mqlight.api.impl.engine.SubscribeResponse;
 import com.ibm.mqlight.api.impl.engine.UnsubscribeRequest;
 import com.ibm.mqlight.api.impl.engine.UnsubscribeResponse;
 import com.ibm.mqlight.api.timer.TimerService;
+import junit.framework.AssertionFailedError;
 
 public class TestNonBlockingClientImpl {
 
@@ -505,7 +504,7 @@ public class TestNonBlockingClientImpl {
                 final byte[] actual = (byte[]) actualProperties.get(expectedProperty.getKey());
                 for (int i = 0; i < expected.length; i++) {
                     assertTrue("Round-tripped Byte array should match for key: "+expectedProperty.getKey(),
-                            expected[i].byteValue() == actual[i]);
+                            expected[i] == actual[i]);
                 }
             } else if (expectedProperty.getValue() instanceof byte[]) {
                 assertTrue("Round-tripped byte array should match for key: "+expectedProperty.getKey(),
@@ -1086,10 +1085,10 @@ public class TestNonBlockingClientImpl {
         assertEquals("Message 5: content type set incorrectly", "application/json", msg.getContentType());
         assertEquals("Message 5: body doesn't match", expectedRawJson, ((AmqpValue)msg.getBody()).getValue());
     }
-    
+
     /**
-     * Ensure that breakInboundLinks completes when requests have been added to sd.pending  
-     * 
+     * Ensure that breakInboundLinks completes when requests have been added to sd.pending
+     *
      * @throws InterruptedException
      */
     @Test(timeout=5000)
@@ -1113,7 +1112,7 @@ public class TestNonBlockingClientImpl {
                     Exception exception) {
                 done.release();
             }
-            
+
         }, null);
         client.tell(new SubscribeResponse(engineConnection, new SubscriptionTopic("/kittens", null)), engine);
         assertTrue("Client failed to subscribe within timeout. ", done.tryAcquire(4, TimeUnit.SECONDS));

--- a/mqlight/src/test/java/com/ibm/mqlight/api/impl/engine/MockNetworkChannel.java
+++ b/mqlight/src/test/java/com/ibm/mqlight/api/impl/engine/MockNetworkChannel.java
@@ -43,7 +43,7 @@ public class MockNetworkChannel implements NetworkChannel {
     private final Transport transport;
     private final Collector collector;
     private Object context = null;
-    
+
     public MockNetworkChannel(NetworkListener listener, Handler handler) {
         this.listener = listener;
         this.handler = handler;
@@ -56,10 +56,10 @@ public class MockNetworkChannel implements NetworkChannel {
         transport.bind(connection);
         Sasl sasl = transport.sasl();
         sasl.server();
-        sasl.setMechanisms(new String[]{"ANONYMOUS"});
+        sasl.setMechanisms("ANONYMOUS");
         sasl.done(Sasl.SaslOutcome.PN_SASL_OK);
     }
-    
+
     @Override
     public void close(Promise<Void> promise) {
         if (promise != null) promise.setSuccess(null);
@@ -79,7 +79,7 @@ public class MockNetworkChannel implements NetworkChannel {
                 event.dispatch(handler);
                 collector.pop();
             }
-            
+
         }
         process();
     }
@@ -96,7 +96,7 @@ public class MockNetworkChannel implements NetworkChannel {
             listener.onRead(this, buf);
         }
     }
-    
+
     @Override
     public void setContext(Object context) {
         this.context = context;

--- a/mqlight/src/test/java/com/ibm/mqlight/api/impl/logging/TestLoggerImpl.java
+++ b/mqlight/src/test/java/com/ibm/mqlight/api/impl/logging/TestLoggerImpl.java
@@ -46,7 +46,7 @@ public class TestLoggerImpl {
     public ReloadClassLoader(String loadFailClassName) {
       this.loadFailClassName = loadFailClassName;
     }
-    
+
     @Override
     public Class<?> loadClass(String className) throws ClassNotFoundException {
       if (className.startsWith("com.ibm.mqlight")) {
@@ -78,19 +78,19 @@ public class TestLoggerImpl {
       }
     }
   }
-  
+
   @Test
   public void testLoadError() throws IllegalAccessException, IllegalArgumentException, InvocationTargetException, NoSuchMethodException, SecurityException, ClassNotFoundException {
     final ReloadClassLoader loader = new ReloadClassLoader(LoggerFactory.LOGGER_FACTORY_IMPL_CLASS_NAME);
     try {
       Class<?> loggerFactory = loader.loadClass("com.ibm.mqlight.api.logging.LoggerFactory");
-      Method method = loggerFactory.getMethod("getLogger", new Class<?> [] { Class.class });
-      method.invoke(null, new Object [] { getClass() });
+      Method method = loggerFactory.getMethod("getLogger", Class.class);
+      method.invoke(null, getClass());
       fail("expected and exception to be thrown");
     } catch (Error e) {
     }
   }
-  
+
   @Test
   public void testClientId() {
 
@@ -98,7 +98,7 @@ public class TestLoggerImpl {
     final Logger testLogger = LoggerFactory.getLogger(logger);
     testLogger.setClientId("TestClientId");
     final String clientId = MDC.get(Logger.CLIENTID_KEY);
-    
+
     assertEquals("Expected client id to be set", "TestClientId", clientId);
   }
 
@@ -114,14 +114,14 @@ public class TestLoggerImpl {
     assertEquals("Unexpected message", "test info message", event.message);
     assertNull("Unexpected throwable", event.throwable);
     assertEquals("Unexpected args", 0, event.args.length);
-    
+
     try {
       event = logger.getEvent();
       fail("Unexpected event: "+event);
     } catch(NoSuchElementException e) {
     }
   }
-  
+
   @Test
   public void testWarning() {
 
@@ -134,14 +134,14 @@ public class TestLoggerImpl {
     assertEquals("Unexpected message", "test warning message", event.message);
     assertNull("Unexpected throwable", event.throwable);
     assertEquals("Unexpected args", 0, event.args.length);
-    
+
     try {
       event = logger.getEvent();
       fail("Unexpected event: "+event);
     } catch(NoSuchElementException e) {
     }
   }
-   
+
   @Test
   public void testError() {
 
@@ -154,7 +154,7 @@ public class TestLoggerImpl {
     assertEquals("Unexpected message", "test error message", event.message);
     assertNull("Unexpected throwable", event.throwable);
     assertEquals("Unexpected args", 0, event.args.length);
-    
+
     Exception testException = new Exception("error exception");
     testLogger.error("test error message2", testException);
     event = logger.getEvent();
@@ -163,14 +163,14 @@ public class TestLoggerImpl {
     assertEquals("Unexpected message", "test error message2", event.message);
     assertEquals("Unexpected throwable", testException, event.throwable);
     assertEquals("Unexpected args", 0, event.args.length);
-    
+
     try {
       event = logger.getEvent();
       fail("Unexpected event: "+event);
     } catch(NoSuchElementException e) {
     }
   }
-  
+
   @Test
   public void testEntry() {
 
@@ -185,7 +185,7 @@ public class TestLoggerImpl {
     assertNull("Unexpected throwable", event.throwable);
     assertNull("Unexpected object", event.args[0]);
     assertEquals("Unexpected args", 1, event.args.length);
-    
+
     testLogger.entry(this, methodName);
     event = logger.getEvent();
     assertEquals("Unexpected type", "trace", event.type);
@@ -194,7 +194,7 @@ public class TestLoggerImpl {
     assertNull("Unexpected throwable", event.throwable);
     assertEquals("Unexpected object", this, event.args[0]);
     assertEquals("Unexpected args", 1, event.args.length);
-    
+
     Integer arg1 = 123;
     String arg2 = "abc";
     testLogger.entry(methodName, arg1, arg2);
@@ -207,7 +207,7 @@ public class TestLoggerImpl {
     assertEquals("Unexpected arg1", arg1, event.args[1]);
     assertEquals("Unexpected arg2", arg2, event.args[2]);
     assertEquals("Unexpected args", 3, event.args.length);
-    
+
     arg1 = 567;
     arg2 = "jgf";
     ProcessBuilder arg3 = new ProcessBuilder();
@@ -222,14 +222,14 @@ public class TestLoggerImpl {
     assertEquals("Unexpected arg2", arg2, event.args[2]);
     assertEquals("Unexpected arg2", arg3, event.args[3]);
     assertEquals("Unexpected args", 4, event.args.length);
-    
+
     try {
       event = logger.getEvent();
       fail("Unexpected event: "+event);
     } catch(NoSuchElementException e) {
     }
   }
-  
+
   @Test
   public void testExit() {
 
@@ -244,7 +244,7 @@ public class TestLoggerImpl {
     assertNull("Unexpected throwable", event.throwable);
     assertNull("Unexpected object", event.args[0]);
     assertEquals("Unexpected args", 1, event.args.length);
-    
+
     testLogger.exit(this, methodName);
     event = logger.getEvent();
     assertEquals("Unexpected type", "trace", event.type);
@@ -253,7 +253,7 @@ public class TestLoggerImpl {
     assertNull("Unexpected throwable", event.throwable);
     assertEquals("Unexpected object", this, event.args[0]);
     assertEquals("Unexpected args", 1, event.args.length);
-    
+
     Integer result1 = 123;
     testLogger.exit(methodName, result1);
     event = logger.getEvent();
@@ -264,7 +264,7 @@ public class TestLoggerImpl {
     assertNull("Unexpected object", event.args[0]);
     assertEquals("Unexpected arg1", result1, event.args[1]);
     assertEquals("Unexpected args", 2, event.args.length);
-    
+
     ProcessBuilder result2 = new ProcessBuilder();
     testLogger.exit(this, methodName, result2);
     event = logger.getEvent();
@@ -275,14 +275,14 @@ public class TestLoggerImpl {
     assertEquals("Unexpected object", this, event.args[0]);
     assertEquals("Unexpected arg1", result2, event.args[1]);
     assertEquals("Unexpected args", 2, event.args.length);
-    
+
     try {
       event = logger.getEvent();
       fail("Unexpected event: "+event);
     } catch(NoSuchElementException e) {
     }
   }
-  
+
   @Test
   public void testData() {
 
@@ -297,7 +297,7 @@ public class TestLoggerImpl {
     assertNull("Unexpected throwable", event.throwable);
     assertNull("Unexpected object", event.args[0]);
     assertEquals("Unexpected args", 1, event.args.length);
-    
+
     testLogger.data(this, methodName);
     event = logger.getEvent();
     assertEquals("Unexpected type", "trace", event.type);
@@ -306,7 +306,7 @@ public class TestLoggerImpl {
     assertNull("Unexpected throwable", event.throwable);
     assertEquals("Unexpected object", this, event.args[0]);
     assertEquals("Unexpected args", 1, event.args.length);
-    
+
     Integer arg1 = 123;
     String arg2 = "abc";
     testLogger.data(methodName, arg1, arg2);
@@ -319,7 +319,7 @@ public class TestLoggerImpl {
     assertEquals("Unexpected arg1", arg1, event.args[1]);
     assertEquals("Unexpected arg2", arg2, event.args[2]);
     assertEquals("Unexpected args", 3, event.args.length);
-    
+
     arg1 = 567;
     arg2 = "jgf";
     ProcessBuilder arg3 = new ProcessBuilder();
@@ -334,14 +334,14 @@ public class TestLoggerImpl {
     assertEquals("Unexpected arg2", arg2, event.args[2]);
     assertEquals("Unexpected arg2", arg3, event.args[3]);
     assertEquals("Unexpected args", 4, event.args.length);
-    
+
     try {
       event = logger.getEvent();
       fail("Unexpected event: "+event);
     } catch(NoSuchElementException e) {
     }
   }
-  
+
   @Test
   public void testThrowing() {
 
@@ -357,7 +357,7 @@ public class TestLoggerImpl {
     assertEquals("Unexpected throwable", testException, event.throwable);
     assertNull("Unexpected object", event.args[0]);
     assertEquals("Unexpected args", 1, event.args.length);
-    
+
     // Note that the test below shows up potentially unexpected behaviour as the testException gets treated as a regular argument (i.e. the underlying called org.slf4j.Logger.trace
     // method is not one with a Throwable argument (the MockEvent test class has logic to deal with this behaviour)
     testLogger.throwing(this, "testThrowingMethod", testException);
@@ -368,14 +368,14 @@ public class TestLoggerImpl {
     assertEquals("Unexpected throwable", testException, event.throwable);
     assertEquals("Unexpected object", this, event.args[0]);
     assertEquals("Unexpected args", 1, event.args.length);
-    
+
     try {
       event = logger.getEvent();
       fail("Unexpected event: "+event);
     } catch(NoSuchElementException e) {
     }
   }
-  
+
   @Test
   public void testFFDC() {
 
@@ -384,7 +384,7 @@ public class TestLoggerImpl {
     final String methodName = "testFFDCMethod";
     final Exception exception = new Exception("TestExceptionForFFDC");
     testLogger.ffdc(this, methodName, FFDCProbeId.PROBE_007, exception, "data1", "data2");
-    
+
     MockEvent event = logger.getEvent();
     System.out.println(event.message);
     assertEquals("Unexpected type", "error", event.type);
@@ -400,12 +400,12 @@ public class TestLoggerImpl {
     System.out.println(event.message);
     assertEquals("Unexpected type", "info", event.type);
     assertTrue("Unexpected message", event.message.startsWith("Javacore diagnostic information"));
-    
+
     try {
       event = logger.getEvent();
       fail("Unexpected event: "+event);
     } catch(NoSuchElementException e) {
     }
   }
- 
+
 }

--- a/mqlight/src/test/java/com/ibm/mqlight/api/impl/logging/logback/TestArgsConverter.java
+++ b/mqlight/src/test/java/com/ibm/mqlight/api/impl/logging/logback/TestArgsConverter.java
@@ -34,10 +34,10 @@ public class TestArgsConverter {
   public void testConvertWithUnexpectedEvents() {
 
     final ArgsConverter converter = new ArgsConverter();
-    
+
     assertEquals("Unexpected convertion", "", converter.convert(new MockILoggingEvent()));
-    assertEquals("Unexpected convertion", "", converter.convert(new MockILoggingEvent(null, LogMarker.ENTRY.getValue(), "message", new Object [] {})));
-    assertEquals("Unexpected convertion", "", converter.convert(new MockILoggingEvent(null, LogMarker.EXIT.getValue(), "message", new Object [] {})));
+    assertEquals("Unexpected convertion", "", converter.convert(new MockILoggingEvent(null, LogMarker.ENTRY.getValue(), "message")));
+    assertEquals("Unexpected convertion", "", converter.convert(new MockILoggingEvent(null, LogMarker.EXIT.getValue(), "message")));
   }
 
   @Test
@@ -45,11 +45,11 @@ public class TestArgsConverter {
 
     final ArgsConverter converter = new ArgsConverter();
 
-    assertEquals("Unexpected convertion", "", converter.convert(new MockILoggingEvent(null, LogMarker.EXIT.getValue(), "message", new Object[] { "arg1" })));
-    assertEquals("Unexpected convertion", " returns [null]", converter.convert(new MockILoggingEvent(null, LogMarker.EXIT.getValue(), "message", new Object[] { "arg1", null })));
-    assertEquals("Unexpected convertion", " returns [arg2]", converter.convert(new MockILoggingEvent(null, LogMarker.EXIT.getValue(), "message", new Object[] { "arg1", "arg2" })));
+    assertEquals("Unexpected convertion", "", converter.convert(new MockILoggingEvent(null, LogMarker.EXIT.getValue(), "message", "arg1")));
+    assertEquals("Unexpected convertion", " returns [null]", converter.convert(new MockILoggingEvent(null, LogMarker.EXIT.getValue(), "message", "arg1", null)));
+    assertEquals("Unexpected convertion", " returns [arg2]", converter.convert(new MockILoggingEvent(null, LogMarker.EXIT.getValue(), "message", "arg1", "arg2")));
     assertEquals("Unexpected convertion", " returns [arg2]",
-        converter.convert(new MockILoggingEvent(null, LogMarker.EXIT.getValue(), "message", new Object[] { "arg1", "arg2", "arg3" })));
+        converter.convert(new MockILoggingEvent(null, LogMarker.EXIT.getValue(), "message", "arg1", "arg2", "arg3")));
   }
 
   @Test
@@ -57,15 +57,15 @@ public class TestArgsConverter {
 
     final ArgsConverter converter = new ArgsConverter();
 
-    assertEquals("Unexpected convertion", "", converter.convert(new MockILoggingEvent(null, LogMarker.ENTRY.getValue(), "message", new Object[] { "arg1" })));
-    assertEquals("Unexpected convertion", " [null]", converter.convert(new MockILoggingEvent(null, LogMarker.DATA.getValue(), "message", new Object[] { "arg1", null })));
-    assertEquals("Unexpected convertion", " [arg2]", converter.convert(new MockILoggingEvent(null, LogMarker.ENTRY.getValue(), "message", new Object[] { "arg1", "arg2" })));
+    assertEquals("Unexpected convertion", "", converter.convert(new MockILoggingEvent(null, LogMarker.ENTRY.getValue(), "message", "arg1")));
+    assertEquals("Unexpected convertion", " [null]", converter.convert(new MockILoggingEvent(null, LogMarker.DATA.getValue(), "message", "arg1", null)));
+    assertEquals("Unexpected convertion", " [arg2]", converter.convert(new MockILoggingEvent(null, LogMarker.ENTRY.getValue(), "message", "arg1", "arg2")));
     assertEquals("Unexpected convertion", " [arg2] [123]",
-        converter.convert(new MockILoggingEvent(null, LogMarker.DATA.getValue(), "message", new Object[] { "arg1", "arg2", 123 })));
+        converter.convert(new MockILoggingEvent(null, LogMarker.DATA.getValue(), "message", "arg1", "arg2", 123)));
     assertEquals("Unexpected convertion", " [45] [foo] [true] [file://tmp/bar.txt]",
-        converter.convert(new MockILoggingEvent(null, LogMarker.DATA.getValue(), "message", new Object[] { "arg1", 45, "foo", true, new URL("file://tmp/bar.txt") })));
+        converter.convert(new MockILoggingEvent(null, LogMarker.DATA.getValue(), "message", "arg1", 45, "foo", true, new URL("file://tmp/bar.txt"))));
     assertEquals("Unexpected convertion", " [java.lang.Exception: test exception]",
-        converter.convert(new MockILoggingEvent(null, LogMarker.THROWING.getValue(), "message", new Object[] { "arg1", new Exception("test exception") })));
+        converter.convert(new MockILoggingEvent(null, LogMarker.THROWING.getValue(), "message", "arg1", new Exception("test exception"))));
   }
-  
+
 }

--- a/mqlight/src/test/java/com/ibm/mqlight/api/impl/logging/logback/TestClientIdConverter.java
+++ b/mqlight/src/test/java/com/ibm/mqlight/api/impl/logging/logback/TestClientIdConverter.java
@@ -32,13 +32,13 @@ public class TestClientIdConverter {
   @Test
   public void testConvertWithClientIdNotSet() {
     MDC.clear();
-    
+
     final ClientIdConverter converter = new ClientIdConverter();
-    
+
     assertEquals("Unexpected convertion", "*", converter.convert(new MockILoggingEvent()));
-    assertEquals("Unexpected convertion", "*", converter.convert(new MockILoggingEvent(null, LogMarker.ENTRY.getValue(), "message", new Object [] {})));
-    assertEquals("Unexpected convertion", "*", converter.convert(new MockILoggingEvent(null, LogMarker.EXIT.getValue(), "message", new Object [] {})));
-    
+    assertEquals("Unexpected convertion", "*", converter.convert(new MockILoggingEvent(null, LogMarker.ENTRY.getValue(), "message")));
+    assertEquals("Unexpected convertion", "*", converter.convert(new MockILoggingEvent(null, LogMarker.EXIT.getValue(), "message")));
+
     MockILoggingEvent event = new MockILoggingEvent();
     event.setNullMDC(true);
     assertEquals("Unexpected convertion", "*", converter.convert(new MockILoggingEvent()));
@@ -48,30 +48,30 @@ public class TestClientIdConverter {
   public void testConvertWithClientIdSetToNull() {
     MDC.put(Logger.CLIENTID_KEY, null);
     final ClientIdConverter converter = new ClientIdConverter();
-    
+
     assertEquals("Unexpected convertion", "*", converter.convert(new MockILoggingEvent()));
-    assertEquals("Unexpected convertion", "*", converter.convert(new MockILoggingEvent(null, LogMarker.ENTRY.getValue(), "message", new Object [] {})));
-    assertEquals("Unexpected convertion", "*", converter.convert(new MockILoggingEvent(null, LogMarker.EXIT.getValue(), "message", new Object [] {})));
+    assertEquals("Unexpected convertion", "*", converter.convert(new MockILoggingEvent(null, LogMarker.ENTRY.getValue(), "message")));
+    assertEquals("Unexpected convertion", "*", converter.convert(new MockILoggingEvent(null, LogMarker.EXIT.getValue(), "message")));
   }
 
   @Test
   public void testConvertWithClientIdSetBlank() {
     MDC.put(Logger.CLIENTID_KEY, "");
     final ClientIdConverter converter = new ClientIdConverter();
-    
+
     assertEquals("Unexpected convertion", "", converter.convert(new MockILoggingEvent()));
-    assertEquals("Unexpected convertion", "", converter.convert(new MockILoggingEvent(null, LogMarker.ENTRY.getValue(), "message", new Object [] {})));
-    assertEquals("Unexpected convertion", "", converter.convert(new MockILoggingEvent(null, LogMarker.EXIT.getValue(), "message", new Object [] {})));
+    assertEquals("Unexpected convertion", "", converter.convert(new MockILoggingEvent(null, LogMarker.ENTRY.getValue(), "message")));
+    assertEquals("Unexpected convertion", "", converter.convert(new MockILoggingEvent(null, LogMarker.EXIT.getValue(), "message")));
   }
-  
+
   @Test
   public void testConvertWithClientIdSet() {
     MDC.put(Logger.CLIENTID_KEY, "id");
     final ClientIdConverter converter = new ClientIdConverter();
-    
+
     assertEquals("Unexpected convertion", "id", converter.convert(new MockILoggingEvent()));
-    assertEquals("Unexpected convertion", "id", converter.convert(new MockILoggingEvent(null, LogMarker.ENTRY.getValue(), "message", new Object [] {})));
-    assertEquals("Unexpected convertion", "id", converter.convert(new MockILoggingEvent(null, LogMarker.EXIT.getValue(), "message", new Object [] {})));
+    assertEquals("Unexpected convertion", "id", converter.convert(new MockILoggingEvent(null, LogMarker.ENTRY.getValue(), "message")));
+    assertEquals("Unexpected convertion", "id", converter.convert(new MockILoggingEvent(null, LogMarker.EXIT.getValue(), "message")));
   }
-  
+
 }

--- a/mqlight/src/test/java/com/ibm/mqlight/api/impl/logging/logback/TestIndentConverter.java
+++ b/mqlight/src/test/java/com/ibm/mqlight/api/impl/logging/logback/TestIndentConverter.java
@@ -34,14 +34,14 @@ public class TestIndentConverter {
     final IndentConverter converter = new IndentConverter();
 
     assertEquals("Unexpected convertion", " ", converter.convert(new MockILoggingEvent()));
-    assertEquals("Unexpected convertion", " ", converter.convert(new MockILoggingEvent(null, MarkerFactory.getMarker("unknown"), "message", new Object[] {})));
-    assertEquals("Unexpected convertion", "{", converter.convert(new MockILoggingEvent(null, LogMarker.ENTRY.getValue(), "message", new Object[] {})));
-    assertEquals("Unexpected convertion", "}", converter.convert(new MockILoggingEvent(null, LogMarker.EXIT.getValue(), "message", new Object[] {})));
-    assertEquals("Unexpected convertion", "d", converter.convert(new MockILoggingEvent(null, LogMarker.DATA.getValue(), "message", new Object[] {})));
-    assertEquals("Unexpected convertion", "!", converter.convert(new MockILoggingEvent(null, LogMarker.THROWING.getValue(), "message", new Object[] {})));
-    assertEquals("Unexpected convertion", "i", converter.convert(new MockILoggingEvent(null, LogMarker.INFO.getValue(), "message", new Object[] {})));
-    assertEquals("Unexpected convertion", "w", converter.convert(new MockILoggingEvent(null, LogMarker.WARNING.getValue(), "message", new Object[] {})));
-    assertEquals("Unexpected convertion", "e", converter.convert(new MockILoggingEvent(null, LogMarker.ERROR.getValue(), "message", new Object[] {})));
-    assertEquals("Unexpected convertion", "f", converter.convert(new MockILoggingEvent(null, LogMarker.FFDC.getValue(), "message", new Object[] {})));
+    assertEquals("Unexpected convertion", " ", converter.convert(new MockILoggingEvent(null, MarkerFactory.getMarker("unknown"), "message")));
+    assertEquals("Unexpected convertion", "{", converter.convert(new MockILoggingEvent(null, LogMarker.ENTRY.getValue(), "message")));
+    assertEquals("Unexpected convertion", "}", converter.convert(new MockILoggingEvent(null, LogMarker.EXIT.getValue(), "message")));
+    assertEquals("Unexpected convertion", "d", converter.convert(new MockILoggingEvent(null, LogMarker.DATA.getValue(), "message")));
+    assertEquals("Unexpected convertion", "!", converter.convert(new MockILoggingEvent(null, LogMarker.THROWING.getValue(), "message")));
+    assertEquals("Unexpected convertion", "i", converter.convert(new MockILoggingEvent(null, LogMarker.INFO.getValue(), "message")));
+    assertEquals("Unexpected convertion", "w", converter.convert(new MockILoggingEvent(null, LogMarker.WARNING.getValue(), "message")));
+    assertEquals("Unexpected convertion", "e", converter.convert(new MockILoggingEvent(null, LogMarker.ERROR.getValue(), "message")));
+    assertEquals("Unexpected convertion", "f", converter.convert(new MockILoggingEvent(null, LogMarker.FFDC.getValue(), "message")));
   }
 }

--- a/mqlight/src/test/java/com/ibm/mqlight/api/impl/logging/logback/TestLevelConverter.java
+++ b/mqlight/src/test/java/com/ibm/mqlight/api/impl/logging/logback/TestLevelConverter.java
@@ -34,9 +34,9 @@ public class TestLevelConverter {
     final LevelConverter converter = new LevelConverter();
 
     assertEquals("Unexpected convertion", "", converter.convert(new MockILoggingEvent()));
-    assertEquals("Unexpected convertion", "", converter.convert(new MockILoggingEvent(null, null, "message", new Object[] {})));
-    assertEquals("Unexpected convertion", "INFO", converter.convert(new MockILoggingEvent(Level.INFO, null, "message", new Object[] {})));
-    assertEquals("Unexpected convertion", "mark", converter.convert(new MockILoggingEvent(null, MarkerFactory.getMarker("mark"), "message", new Object[] {})));
-    assertEquals("Unexpected convertion", "mark", converter.convert(new MockILoggingEvent(Level.INFO, MarkerFactory.getMarker("mark"), "message", new Object[] {})));
+    assertEquals("Unexpected convertion", "", converter.convert(new MockILoggingEvent(null, null, "message")));
+    assertEquals("Unexpected convertion", "INFO", converter.convert(new MockILoggingEvent(Level.INFO, null, "message")));
+    assertEquals("Unexpected convertion", "mark", converter.convert(new MockILoggingEvent(null, MarkerFactory.getMarker("mark"), "message")));
+    assertEquals("Unexpected convertion", "mark", converter.convert(new MockILoggingEvent(Level.INFO, MarkerFactory.getMarker("mark"), "message")));
   }
 }

--- a/mqlight/src/test/java/com/ibm/mqlight/api/impl/logging/logback/TestObjectIdlConverter.java
+++ b/mqlight/src/test/java/com/ibm/mqlight/api/impl/logging/logback/TestObjectIdlConverter.java
@@ -34,10 +34,10 @@ public class TestObjectIdlConverter {
 
     assertEquals("Unexpected convertion", "", converter.convert(new MockILoggingEvent()));
     assertEquals("Unexpected convertion", "", converter.convert(new MockILoggingEvent(null, null, "message", (Object[]) null)));
-    assertEquals("Unexpected convertion", "", converter.convert(new MockILoggingEvent(null, null, "message", new Object[] {})));
+    assertEquals("Unexpected convertion", "", converter.convert(new MockILoggingEvent(null, null, "message")));
     assertEquals("Unexpected convertion", "", converter.convert(new MockILoggingEvent(null, null, "message", new Object[] { null })));
     assertEquals("Unexpected convertion", "", converter.convert(new MockILoggingEvent(null, LogMarker.ERROR.getValue(), "message", new Object[] { null })));
-    assertEquals("Unexpected convertion", "", converter.convert(new MockILoggingEvent(null, LogMarker.ENTRY.getValue(), "message", new Object[] {})));
+    assertEquals("Unexpected convertion", "", converter.convert(new MockILoggingEvent(null, LogMarker.ENTRY.getValue(), "message")));
     assertEquals("Unexpected convertion", "static", converter.convert(new MockILoggingEvent(null, LogMarker.ENTRY.getValue(), "message", new Object[] { null })));
     assertEquals("Unexpected convertion", "static", converter.convert(new MockILoggingEvent(null, LogMarker.EXIT.getValue(), "message", new Object[] { null })));
     assertEquals("Unexpected convertion", "static", converter.convert(new MockILoggingEvent(null, LogMarker.DATA.getValue(), "message", new Object[] { null })));
@@ -45,11 +45,11 @@ public class TestObjectIdlConverter {
 
     final String obj = new String("id");
     final String objId = Integer.toHexString(System.identityHashCode(obj));
-    assertEquals("Unexpected convertion", "", converter.convert(new MockILoggingEvent(null, null, "message", new Object[] { obj })));
-    assertEquals("Unexpected convertion", "", converter.convert(new MockILoggingEvent(null, LogMarker.WARNING.getValue(), "message", new Object[] { obj })));
-    assertEquals("Unexpected convertion", "@"+objId, converter.convert(new MockILoggingEvent(null, LogMarker.ENTRY.getValue(), "message", new Object[] { obj })));
-    assertEquals("Unexpected convertion", "@"+objId, converter.convert(new MockILoggingEvent(null, LogMarker.EXIT.getValue(), "message", new Object[] { obj })));
-    assertEquals("Unexpected convertion", "@"+objId, converter.convert(new MockILoggingEvent(null, LogMarker.DATA.getValue(), "message", new Object[] { obj })));
-    assertEquals("Unexpected convertion", "@"+objId, converter.convert(new MockILoggingEvent(null, LogMarker.THROWING.getValue(), "message", new Object[] { obj })));
+    assertEquals("Unexpected convertion", "", converter.convert(new MockILoggingEvent(null, null, "message", obj)));
+    assertEquals("Unexpected convertion", "", converter.convert(new MockILoggingEvent(null, LogMarker.WARNING.getValue(), "message", obj)));
+    assertEquals("Unexpected convertion", "@"+objId, converter.convert(new MockILoggingEvent(null, LogMarker.ENTRY.getValue(), "message", obj)));
+    assertEquals("Unexpected convertion", "@"+objId, converter.convert(new MockILoggingEvent(null, LogMarker.EXIT.getValue(), "message", obj)));
+    assertEquals("Unexpected convertion", "@"+objId, converter.convert(new MockILoggingEvent(null, LogMarker.DATA.getValue(), "message", obj)));
+    assertEquals("Unexpected convertion", "@"+objId, converter.convert(new MockILoggingEvent(null, LogMarker.THROWING.getValue(), "message", obj)));
   }
 }

--- a/mqlight/src/test/java/com/ibm/mqlight/api/impl/timer/TestTimerService.java
+++ b/mqlight/src/test/java/com/ibm/mqlight/api/impl/timer/TestTimerService.java
@@ -32,9 +32,9 @@ public class TestTimerService {
 
     private class MockPromise implements Promise<Void> {
         private AtomicBoolean complete = new AtomicBoolean(false);
-        private AtomicBoolean setFailureCalled = new AtomicBoolean(false);;
-        private AtomicBoolean setSuccessCalled = new AtomicBoolean(false);;
-        
+        private AtomicBoolean setFailureCalled = new AtomicBoolean(false);
+        private AtomicBoolean setSuccessCalled = new AtomicBoolean(false);
+
         @Override
         public void setFailure(Exception exception) throws IllegalStateException {
             if (complete.getAndSet(true)) throw new IllegalStateException();
@@ -51,7 +51,7 @@ public class TestTimerService {
         public boolean isComplete() {
             return complete.get();
         }
-        
+
     }
 
     @Test
@@ -66,20 +66,20 @@ public class TestTimerService {
             Thread.sleep(50);
         }
         long t2 = System.currentTimeMillis();
-        
+
         assertTrue("Promise should have completed by now!", promise.isComplete());
         long elapsed = t2 - t1;
         if (elapsed < 150) throw new AssertionFailedError("Promise completed too quickly in " + elapsed +"ms (expected 250ms)");
         assertFalse("Promise should not have been marked as failed", promise.setFailureCalled.get());
     }
-    
+
     @Test
     public void cancel() throws InterruptedException {
         TimerService timer = new TimerServiceImpl();
         MockPromise promise = new MockPromise();
         timer.schedule(250, promise);
         timer.cancel(promise);
-        
+
         long t1 = System.currentTimeMillis();
         for (int i = 0; i < 10; ++i) {
             if (promise.isComplete()) break;
@@ -91,7 +91,7 @@ public class TestTimerService {
         if (elapsed > 150) throw new AssertionFailedError("Promise completed too slowly in " + elapsed +"ms (expected < 150ms)");
         assertFalse("Promise should not have been marked as successful", promise.setSuccessCalled.get());
     }
-    
+
     @Test
     public void cancelCompleted() throws InterruptedException {
         TimerService timer = new TimerServiceImpl();
@@ -103,7 +103,7 @@ public class TestTimerService {
             Thread.sleep(50);
         }
         assertTrue("Promise should have completed by now!", promise.isComplete());
-        
+
         timer.cancel(promise);   // Should have no ill effects...
     }
 }


### PR DESCRIPTION
- Don't use public on interface
- Replace new Object[] { "a", "b" } with "a", "b" for var args
- Use string concatenation in toString methods
- Use StringBuilder in loops
- Removed redundant type declarations
- Simplify some expressions
