### PR TITLE
Add SendOptions.retainLink to allow SenderLink to be closed after use

### DIFF
--- a/mqlight-samples/src/main/java/com/ibm/mqlight/api/samples/Send.java
+++ b/mqlight-samples/src/main/java/com/ibm/mqlight/api/samples/Send.java
@@ -95,6 +95,7 @@ public class Send {
             if (args.containsKey("--message-ttl")) {
                 optsBuilder.setTtl((Integer)args.get("--message-ttl") * 1000);
             }
+            optsBuilder.setRetainLink(repeat > 1);
             opts = optsBuilder.build();
         }
 
@@ -145,7 +146,7 @@ public class Send {
               .expect("-r", "--repeat", Integer.class, 1)
               .expect(null, "--sequence", Boolean.class, null)
               .expect("-f", "--file", String.class, null);
-        ArgumentParser.Results tmpArgs = null;;
+        ArgumentParser.Results tmpArgs = null;
         try {
             tmpArgs = parser.parse(cmdline);
         } catch(IllegalArgumentException e) {
@@ -180,6 +181,7 @@ public class Send {
                 if (args.parsed.containsKey("--message-ttl")) {
                     optsBuilder.setTtl((Integer)args.parsed.get("--message-ttl") * 1000);
                 }
+                optsBuilder.setRetainLink(false);
                 SendOptions opts = optsBuilder.build();
 
                 if (args.parsed.containsKey("-f")) {

--- a/mqlight/src/main/java/com/ibm/mqlight/api/SendOptions.java
+++ b/mqlight/src/main/java/com/ibm/mqlight/api/SendOptions.java
@@ -36,14 +36,16 @@ public class SendOptions {
   
     private final QOS qos;
     private final long ttl;
+    private final boolean retainLink;
 
-    private SendOptions(QOS qos, long ttl) {
+    private SendOptions(QOS qos, long ttl, boolean retainLink) {
         final String methodName = "<init>";
         logger.entry(this, methodName, qos, ttl);
       
         this.qos = qos;
         this.ttl = ttl;
-        
+        this.retainLink = retainLink;
+
         logger.exit(this, methodName);
     }
 
@@ -55,6 +57,10 @@ public class SendOptions {
         return ttl;
     }
 
+    public final boolean getRetainLink() {
+        return retainLink;
+    }
+
     @Override
     public String toString() {
         StringBuilder sb = new StringBuilder(super.toString());
@@ -62,6 +68,8 @@ public class SendOptions {
           .append(qos)
           .append(", ttl=")
           .append(ttl)
+          .append(", retainLink=")
+          .append(retainLink)
           .append("]");
         return sb.toString();
     }
@@ -80,6 +88,7 @@ public class SendOptions {
     public static class SendOptionsBuilder {
         private QOS qos = QOS.AT_MOST_ONCE;
         private long ttl = 0;
+        private boolean retainLink = true;
 
         private SendOptionsBuilder() {}
 
@@ -131,11 +140,30 @@ public class SendOptions {
         }
 
         /**
+         * Set the retainLink option.  True by default this value will determine if the AMQP Link should
+         * be retained by the connection so that it can be re-used for subsequent messages.  When a client
+         * will not send further messages to a given topic this value can be set to false to automatically
+         * close the Link after sending this message.
+         * @param retainLink true if the Link should be retained, false to close after message send.
+         * @return the instance of <code>SendOptionsBuilder</code> that this method was
+         *         called on.
+         */
+        public SendOptionsBuilder setRetainLink(boolean retainLink) {
+            final String methodName = "setRetainLink";
+            logger.entry(this, methodName, retainLink);
+
+            this.retainLink = retainLink;
+
+            logger.exit(this, methodName, this);
+
+            return this;
+        }
+        /**
          * @return an instance of SendOptions based on the current settings of
          *         this builder.
          */
         public SendOptions build() {
-            return new SendOptions(qos, ttl);
+            return new SendOptions(qos, ttl, retainLink);
         }
     }
 

--- a/mqlight/src/main/java/com/ibm/mqlight/api/impl/InternalSend.java
+++ b/mqlight/src/main/java/com/ibm/mqlight/api/impl/InternalSend.java
@@ -32,8 +32,10 @@ class InternalSend<T> extends Message implements QueueableWork {
     final QOS qos;
     final ByteBuf buf;
     final int length;
+    final boolean retainLink;
     final CompletionFuture<T> future;
-    InternalSend(NonBlockingClientImpl client, String topic, QOS qos, ByteBuf buf, int length) {
+
+    InternalSend(NonBlockingClientImpl client, String topic, QOS qos, ByteBuf buf, int length, boolean retainLink) {
         final String methodName = "<init>";
         logger.entry(this, methodName, client, topic, qos, buf, length);
 
@@ -42,6 +44,7 @@ class InternalSend<T> extends Message implements QueueableWork {
         this.qos = qos;
         this.buf = buf;
         this.length = length;
+        this.retainLink = retainLink;
 
         logger.exit(this, methodName);
     }

--- a/mqlight/src/main/java/com/ibm/mqlight/api/impl/NonBlockingClientImpl.java
+++ b/mqlight/src/main/java/com/ibm/mqlight/api/impl/NonBlockingClientImpl.java
@@ -452,7 +452,7 @@ public class NonBlockingClientImpl extends NonBlockingClient implements FSMActio
         }
 
         final ByteBuf buf = io.netty.buffer.Unpooled.wrappedBuffer(data);
-        InternalSend<T> is = new InternalSend<T>(this, topic, sendOptions.getQos(), buf, length);
+        InternalSend<T> is = new InternalSend<T>(this, topic, sendOptions.getQos(), buf, length, sendOptions.getRetainLink());
         ++undrainedSends;
         tell(is, this);
 
@@ -678,7 +678,7 @@ public class NonBlockingClientImpl extends NonBlockingClient implements FSMActio
             InternalSend<?> is = (InternalSend<?>)message;
             NonBlockingClientState state = stateMachine.getState();
             if (NonBlockingClientState.acceptingWorkStates.contains(state)) {
-                SendRequest sr = new SendRequest(currentConnection, is.topic, is.buf, is.length, is.qos);
+                SendRequest sr = new SendRequest(currentConnection, is.topic, is.buf, is.length, is.qos, is.retainLink);
                 outstandingSends.put(sr, is);
                 engine.tell(sr, this);
             } else if (NonBlockingClientState.queueingWorkStates.contains(state)) {

--- a/mqlight/src/main/java/com/ibm/mqlight/api/impl/engine/Engine.java
+++ b/mqlight/src/main/java/com/ibm/mqlight/api/impl/engine/Engine.java
@@ -225,6 +225,9 @@ public class Engine extends ComponentImpl implements Handler {
 
             if (sr.qos == QOS.AT_MOST_ONCE) {
               d.settle();
+              if (!sr.retainLink) {
+                linkSender.close();
+              }
             } else {
               engineConnection.inProgressOutboundDeliveries.put(d, sr);
             }
@@ -849,6 +852,9 @@ public class Engine extends ComponentImpl implements Handler {
               exception = new Exception("Message was released");
           } else if (delivery.getRemoteState() instanceof Modified) {
               exception = new Exception("Message was modified");
+          }
+          if (!sr.retainLink) {
+              event.getLink().close();
           }
           sr.getSender().tell(new SendResponse(sr, exception), this);
       } else if (delivery.isReadable() && !delivery.isPartial()) {    // Assuming link instanceof Receiver...

--- a/mqlight/src/main/java/com/ibm/mqlight/api/impl/engine/SendRequest.java
+++ b/mqlight/src/main/java/com/ibm/mqlight/api/impl/engine/SendRequest.java
@@ -29,12 +29,15 @@ public class SendRequest extends Message {
     protected final ByteBuf buf;
     protected final int length;
     protected final QOS qos;
-    public SendRequest(EngineConnection connection, String topic, ByteBuf buf, int length, QOS qos) {
+    protected final boolean retainLink;
+
+    public SendRequest(EngineConnection connection, String topic, ByteBuf buf, int length, QOS qos, boolean retainLink) {
         this.connection = connection;
         this.topic = topic;
         this.buf = buf;
         this.length = length;
         this.qos = qos;
+        this.retainLink = retainLink;
     }
     
     public void releaseBuf() {

--- a/mqlight/src/test/java/com/ibm/mqlight/api/TestSendOptions.java
+++ b/mqlight/src/test/java/com/ibm/mqlight/api/TestSendOptions.java
@@ -71,3 +71,15 @@ public class TestSendOptions {
         }
     }
 }
+
+    @Test
+    public void retainLinkValues() {
+        SendOptions defaultRetainLinkOpts = SendOptions.builder().build();
+        assertEquals(true, defaultRetainLinkOpts.getRetainLink());
+
+        SendOptions explicitRetainLinkFalseOpts = SendOptions.builder().setRetainLink(false).build();
+        assertEquals(false, explicitRetainLinkFalseOpts.getRetainLink());
+
+        SendOptions explicitRetainLinkTrueOpts = SendOptions.builder().setRetainLink(true).build();
+        assertEquals(true, explicitRetainLinkTrueOpts.getRetainLink());
+    }

--- a/mqlight/src/test/java/com/ibm/mqlight/api/impl/engine/TestEngine.java
+++ b/mqlight/src/test/java/com/ibm/mqlight/api/impl/engine/TestEngine.java
@@ -226,7 +226,7 @@ public class TestEngine {
         engine.tell(expectedOpenRequest, component);
         OpenResponse openResponse = (OpenResponse)component.getMessages().get(0);
 
-        engine.tell(new SendRequest(openResponse.connection, "topic1", wrappedBuffer(new byte[]{1, 2, 3}), 3, QOS.AT_MOST_ONCE), component);
+        engine.tell(new SendRequest(openResponse.connection, "topic1", wrappedBuffer(new byte[]{1, 2, 3}), 3, QOS.AT_MOST_ONCE, true), component);
         assertEquals("Expected two more messages to have been sent to component", 3, component.getMessages().size());
         assertTrue("Expected message 2 to be of type DrainNotification", component.getMessages().get(1) instanceof DrainNotification);
         assertTrue("Expected message 3 to be of type SendResponse", component.getMessages().get(2) instanceof SendResponse);


### PR DESCRIPTION
The SendOptions.retainLink is now used to determine if the SenderLink
is retained after sending the outbound message.  By default the Link
will be retained to avoid re-creating the Link on subsequent messages
to the same destination.  Setting the value to false is useful for
'one-off' topics to allow the Link to be closed and resources released.
