### PR TITLE
Make VCAP_SERVICE parsing more configurable

### DIFF
--- a/mqlight/src/main/java/com/ibm/mqlight/api/impl/NonBlockingClientImpl.java
+++ b/mqlight/src/main/java/com/ibm/mqlight/api/impl/NonBlockingClientImpl.java
@@ -18,6 +18,8 @@
  */
 package com.ibm.mqlight.api.impl;
 
+import io.netty.buffer.ByteBuf;
+
 import java.lang.reflect.Type;
 import java.net.URI;
 import java.nio.BufferOverflowException;
@@ -93,7 +95,6 @@ import com.ibm.mqlight.api.logging.Logger;
 import com.ibm.mqlight.api.logging.LoggerFactory;
 import com.ibm.mqlight.api.network.NetworkService;
 import com.ibm.mqlight.api.timer.TimerService;
-import io.netty.buffer.ByteBuf;
 
 public class NonBlockingClientImpl extends NonBlockingClient implements FSMActions, Component, CallbackService {
 
@@ -245,7 +246,7 @@ public class NonBlockingClientImpl extends NonBlockingClient implements FSMActio
     }
 
     public <T> NonBlockingClientImpl(String service, ClientOptions options, NonBlockingClientListener<T> listener, T context) {
-        this(service == null ? new BluemixEndpointService()
+        this(service == null ? new BluemixEndpointService(null, null)
                 : new SingleEndpointService(service,
                         options == null ? null : options.getUser(),
                         options == null ? null : options.getPassword(),

--- a/mqlight/src/test/java/com/ibm/mqlight/api/impl/endpoint/TestBluemixEndpointService.java
+++ b/mqlight/src/test/java/com/ibm/mqlight/api/impl/endpoint/TestBluemixEndpointService.java
@@ -18,9 +18,11 @@
  */
 package com.ibm.mqlight.api.impl.endpoint;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
+import java.util.regex.Pattern;
 
 import org.junit.Test;
 
@@ -28,18 +30,165 @@ import com.ibm.mqlight.api.impl.endpoint.MockEndpointPromise.Method;
 
 public class TestBluemixEndpointService {
 
+    private final String servicesJson = "{\"service\": [ \"amqp://ep1.example.org\", \"amqp://ep2.example.org\" ]}";
+
+    // Example JSON for a user-provided service
+    private final String expectedUserProvidedUri = "http://mqlight-lookup.stage1.ng.bluemix.net/Lookup?serviceId=74f27d98-5368-4ae6-aad4-5c23798dec92&tls=true";
+    private final String userProvidedJSON =
+            "{" +
+            "  'user-provided': [" +
+            "    {" +
+            "      'name': 'Example MQ Light User Provided'," +
+            "      'label': 'user-provided', "+
+            "      'plan': 'standard'," +
+            "      'credentials': {" +
+            "        'password': 'r2jk9J?!P~/:', " +
+            "        'nonTLSConnectionLookupURI': 'http://mqlight-lookup.stage1.ng.bluemix.net/Lookup?serviceId=74f27d98-5368-4ae6-aad4-5c23798dec92'," +
+            "        'version': '2'," +
+            "        'connectionLookupURI': '" + expectedUserProvidedUri + "'," +
+            "        'username': 'nvAN7VgCXSFS'" +
+            "      }" +
+            "    }" +
+            "  ]" +
+            "}".replace("'", "\"");
+
+
+    // Example JSON for two user-provided services, only one of which is MQ Light related
+    private final String expectedUserProvidedWithNonMQLightUri = "http://mqlight-lookup.stage1.ng.bluemix.net/Lookup?serviceId=74f27d98-5368-4ae6-aad4-5c23798dec92&tls=true";
+    private final String userProvidedWithNonMQLightJSON =
+            "{" +
+            "  'user-provided': [" +
+            "    {" +
+            "      'name': 'MQLightBased'," +
+            "      'label': 'user-provided', "+
+            "      'plan': 'standard'," +
+            "      'credentials': {" +
+            "        'password': 'r2jk9J?!P~/:', " +
+            "        'nonTLSConnectionLookupURI': 'http://mqlight-lookup.stage1.ng.bluemix.net/Lookup?serviceId=74f27d98-5368-4ae6-aad4-5c23798dec92'," +
+            "        'version': '2'," +
+            "        'connectionLookupURI': '" + expectedUserProvidedWithNonMQLightUri + "'," +
+            "        'username': 'nvAN7VgCXSFS'" +
+            "      }" +
+            "    }," +
+            "    {" +
+            "      'name': 'CloudantBased'," +
+            "      'label': 'user-provided', "+
+            "      'plan': 'standard'," +
+            "      'credentials': {" +
+            "        'couch': 'abcdef'," +
+            "        'pass': 'efghij'," +
+            "        'user': 'klmnop'" +
+            "      }" +
+            "    }" +
+            "  ]" +
+            "}".replace("'", "\"");
+
+    // Example JSON for one application bound to two different instances of the
+    // MQ Light service.
+    private final String expectedTwoMQLightServicesUri1 = "http://expectedTwoMQLightServicesUri1";
+    private final String expectedTwoMQLightServicesUri2 = "http://expectedTwoMQLightServicesUri2";
+    private final String twoMQLightServicesJSON =
+            "{" +
+            "  'mqlight': [" +
+            "    {" +
+            "      'name': 'MQ Light-9n'," +
+            "      'label': 'mqlight'," +
+            "      'plan': 'standard'," +
+            "      'credentials': {" +
+            "        'password': 'r2jk9J?!P~/:', " +
+            "        'nonTLSConnectionLookupURI': 'http://mqlight-lookup.stage1.ng.bluemix.net/Lookup?serviceId=74f27d98-5368-4ae6-aad4-5c23798dec92'," +
+            "        'version': '2'," +
+            "        'connectionLookupURI': '"+ expectedTwoMQLightServicesUri1 + "'," +
+            "        'username': 'nvAN7VgCXSFS'" +
+            "      }" +
+            "    }," +
+            "    {" +
+            "      'name': 'MQ Light-gs'," +
+            "      'label': 'mqlight'," +
+            "      'plan': 'standard'," +
+            "      'credentials': {" +
+            "        'password': 'e2Xrn:^uH[xa'," +
+            "        'nonTLSConnectionLookupURI': 'http://mqlight-lookup.stage1.ng.bluemix.net/Lookup?serviceId=021c9e9d-9d77-49bb-b0a6-9d64e04eb444'," +
+            "        'version': '2'," +
+            "        'connectionLookupURI': '"+ expectedTwoMQLightServicesUri2 + "'," +
+            "        'username': 'CmjaVaPqYBa6'" +
+            "      }" +
+            "    }" +
+            "  ]" +
+            "}".replace("'", "\"");
+
+    // Example JSON for a service bound against multiple different providers of
+    // the MQ Light API.
+    private final String expectedMultipleMatchingUri1 = "http://multipleMatchingLabelsJSON/expected1";
+    private final String expectedMultipleMatchingUri2 = "http://multipleMatchingLabelsJSON/expected2";
+    private final String expectedMultipleMatchingUri3 = "http://multipleMatchingLabelsJSON/expected3";
+    private final String multipleMatchingLabelsJSON =
+            "{" +
+            "  'mqlight': [" +
+            "    {" +
+            "      'name': 'MQ Light-9n'," +
+            "      'label': 'mqlight'," +
+            "      'plan': 'standard'," +
+            "      'credentials': {" +
+            "        'password': 'r2jk9J?!P~/:', " +
+            "        'nonTLSConnectionLookupURI': 'http://mqlight-lookup.stage1.ng.bluemix.net/Lookup?serviceId=74f27d98-5368-4ae6-aad4-5c23798dec92'," +
+            "        'version': '2'," +
+            "        'connectionLookupURI': '" + expectedMultipleMatchingUri1 + "'," +
+            "        'username': 'nvAN7VgCXSFS'" +
+            "      }" +
+            "    }" +
+            "  ]," +
+            "  'messagehubincubator': [" +
+            "    {" +
+            "      'name': 'MQ Light-gs'," +
+            "      'label': 'messagehubincubator'," +
+            "      'plan': 'standard'," +
+            "      'credentials': {" +
+            "        'password': 'e2rn:^uH[xa'," +
+            "        'nonTLSConnectionLookupURI': 'http://mqlight-lookup.stage1.ng.bluemix.net/Lookup?serviceId=021c9e9d-9d77-49bb-b0a6-9d64e04eb444'," +
+            "        'version': '2'," +
+            "        'connectionLookupURI': '" + expectedMultipleMatchingUri2 + "'," +
+            "        'username': 'CmjaVaPqYBa6'" +
+            "      }" +
+            "    }" +
+            "  ]," +
+            "  'user-provided': [" +
+            "    {" +
+            "      'name': 'MQLightBased'," +
+            "      'label': 'user-provided', "+
+            "      'plan': 'standard'," +
+            "      'credentials': {" +
+            "        'password': 'r2jk9J?!P~/:', " +
+            "        'nonTLSConnectionLookupURI': 'http://mqlight-lookup.stage1.ng.bluemix.net/Lookup?serviceId=74f27d98-5368-4ae6-aad4-5c23798dec92'," +
+            "        'version': '2'," +
+            "        'connectionLookupURI': '" + expectedMultipleMatchingUri3 + "'," +
+            "        'username': 'nvAN7VgCXSFS'" +
+            "      }" +
+            "    }" +
+            "  ]" +
+            "}".replace("'", "\"");
+
     private class MockBluemixEndpointService extends BluemixEndpointService {
-        
+
         private final String vcapServicesJson;
         private final String expectedUri;
         private final String servicesJson;
-        
+
         protected MockBluemixEndpointService(String vcapServicesJson, String expectedUri, String servicesJson) {
+            super(null, null);
             this.vcapServicesJson = vcapServicesJson;
             this.expectedUri = expectedUri;
             this.servicesJson = servicesJson;
         }
-        
+
+        protected MockBluemixEndpointService(Pattern labelPattern, Pattern namePattern,
+                String vcapServicesJson, String expectedUri, String servicesJson) {
+            super(labelPattern, namePattern);
+            this.vcapServicesJson = vcapServicesJson;
+            this.expectedUri = expectedUri;
+            this.servicesJson = servicesJson;
+        }
+
         @Override
         protected String getVcapServices() {
             return vcapServicesJson;
@@ -51,62 +200,152 @@ public class TestBluemixEndpointService {
             return servicesJson;
         }
     }
-    
+
     @Test
     public void noVcapServices() {
         BluemixEndpointService service = new MockBluemixEndpointService(null, "", "");
-        MockEndpointPromise future = new MockEndpointPromise(Method.FAILURE);
-        service.lookup(future);
-        assertTrue("Future should have been marked done", future.isComplete());
+        MockEndpointPromise promise = new MockEndpointPromise(Method.FAILURE);
+        service.lookup(promise);
+        assertTrue("Promise should have been marked done", promise.isComplete());
     }
-    
+
+    private void waitForComplete(MockEndpointPromise promise) throws InterruptedException {
+        // Promise completed on another thread - need to delay for a reasonable amount of time to allow this to happen.
+        for (int i = 0; i < 20; ++i) {
+            if (promise.isComplete()) break;
+            Thread.sleep(50);
+        }
+    }
+
     @Test
     public void goldenPath() throws InterruptedException {
-        String vcapJson = 
+        String vcapJson =
                 "{ \"mqlight\": [ { \"name\": \"mqlsampleservice\", " +
                 "\"label\": \"mqlight\", \"plan\": \"default\", " +
                 "\"credentials\": { \"username\": \"jBruGnaTHuwq\", " +
                 "\"connectionLookupURI\": \"http://mqlightp-lookup.ng.bluemix.net/Lookup?serviceId=ServiceId_0000000090\", " +
                 "\"password\": \"xhUQve2gdgAN\", \"version\": \"2\" } } ] }";
         String expectedUri = "http://mqlightp-lookup.ng.bluemix.net/Lookup?serviceId=ServiceId_0000000090";
-        String servicesJson = "{\"service\": [ \"amqp://ep1.example.org\", \"amqp://ep2.example.org\" ]}";
         BluemixEndpointService service = new MockBluemixEndpointService(vcapJson, expectedUri, servicesJson);
-        MockEndpointPromise future = new MockEndpointPromise(Method.SUCCESS);
-        service.lookup(future);
-        // Future completed on another thread - need to delay for a reasonable amount of time to allow this to happen.
-        for (int i = 0; i < 20; ++i) {  
-            if (future.isComplete()) break;
-            Thread.sleep(50);
-        }
-        assertTrue("Future should have been marked done", future.isComplete());
-        
+        MockEndpointPromise promise = new MockEndpointPromise(Method.SUCCESS);
+        service.lookup(promise);
+        waitForComplete(promise);
+        assertTrue("Promise should have been marked done", promise.isComplete());
+
         // Expect 1st endpoint to be returned.
-        assertEquals("ep1.example.org", future.getEndoint().getHost());
-        
+        assertEquals("ep1.example.org", promise.getEndoint().getHost());
+
         // If the test asks for another endpoint - it should receive the second.
-        future = new MockEndpointPromise(Method.SUCCESS);
-        service.lookup(future);
-        assertTrue("Future should have been marked done", future.isComplete());
-        assertEquals("ep2.example.org", future.getEndoint().getHost());
-        
+        promise = new MockEndpointPromise(Method.SUCCESS);
+        service.lookup(promise);
+        assertTrue("Promise should have been marked done", promise.isComplete());
+        assertEquals("ep2.example.org", promise.getEndoint().getHost());
+
         // Mark the second endpoint as successful - expect it to be returned again if we ask for another endpoint
-        service.onSuccess(future.getEndoint());
-        future = new MockEndpointPromise(Method.SUCCESS);
-        service.lookup(future);
-        assertTrue("Future should have been marked done", future.isComplete());
-        assertEquals("ep2.example.org", future.getEndoint().getHost());
-        
+        service.onSuccess(promise.getEndoint());
+        promise = new MockEndpointPromise(Method.SUCCESS);
+        service.lookup(promise);
+        assertTrue("Promise should have been marked done", promise.isComplete());
+        assertEquals("ep2.example.org", promise.getEndoint().getHost());
+
         // Asking for another endpoint should return the 1st endpoint...
-        future = new MockEndpointPromise(Method.SUCCESS);
-        service.lookup(future);
-        assertTrue("Future should have been marked done", future.isComplete());
-        assertEquals("ep1.example.org", future.getEndoint().getHost());
-        
+        promise = new MockEndpointPromise(Method.SUCCESS);
+        service.lookup(promise);
+        assertTrue("Promise should have been marked done", promise.isComplete());
+        assertEquals("ep1.example.org", promise.getEndoint().getHost());
+
         // Asking for another endpoint should result in the test being told to wait...
-        future = new MockEndpointPromise(Method.WAIT);
-        service.lookup(future);
-        assertTrue("Future should have been marked done", future.isComplete());
+        promise = new MockEndpointPromise(Method.WAIT);
+        service.lookup(promise);
+        assertTrue("Promise should have been marked done", promise.isComplete());
     }
-    
- // TODO: {"service": [ "amqp://ep1.example.org", "amqp://ep2.example.org" ]}
+
+    // Using the default values (e.g. match all service names) check that the
+    // lookup fails when there is ambiguity about which service name to use.
+    @Test
+    public void ambigiousServiceNameFails() {
+        BluemixEndpointService service = new MockBluemixEndpointService(twoMQLightServicesJSON, "", "");
+        MockEndpointPromise promise = new MockEndpointPromise(Method.FAILURE);
+        service.lookup(promise);
+        assertTrue("Promise should have been marked done", promise.isComplete());
+    }
+
+    // The service name pattern can be used to disambiguate situations where
+    // VCAP_SERVICES contains multiple instances of the MQ Light service
+    @Test
+    public void specificServiceCanBePickedByServiceName() throws InterruptedException {
+        BluemixEndpointService service =
+                new MockBluemixEndpointService(null, Pattern.compile(Pattern.quote("MQ Light-9n")),
+                        twoMQLightServicesJSON, expectedTwoMQLightServicesUri1, servicesJson);
+        MockEndpointPromise promise = new MockEndpointPromise(Method.SUCCESS);
+        service.lookup(promise);
+        waitForComplete(promise);
+        assertTrue("Promise should have been marked done", promise.isComplete());
+
+        service =
+                new MockBluemixEndpointService(null, Pattern.compile("MQ Light\\-gs"), twoMQLightServicesJSON, expectedTwoMQLightServicesUri2, servicesJson);
+        promise = new MockEndpointPromise(Method.SUCCESS);
+        service.lookup(promise);
+        waitForComplete(promise);
+        assertTrue("Promise should have been marked done", promise.isComplete());
+    }
+
+    // Using the default values (e.g. match service labels containing 'mqlight'
+    // and containing 'messagehub') check that the lookup fails when there is
+    // ambiguity about which service label to use.
+    @Test
+    public void ambigiousServiceLabelFails() {
+        BluemixEndpointService service = new MockBluemixEndpointService(multipleMatchingLabelsJSON, "", "");
+        MockEndpointPromise promise = new MockEndpointPromise(Method.FAILURE);
+        service.lookup(promise);
+        assertTrue("Promise should have been marked done", promise.isComplete());
+    }
+
+    // The service label pattern can be used to disambiguate situations where
+    // VCAP_SERVICES contains multiple different services that can match
+    @Test
+    public void specificServiceCanBePickedByLabelName() throws InterruptedException {
+        BluemixEndpointService service =
+                new MockBluemixEndpointService(Pattern.compile("mqlight"), null, multipleMatchingLabelsJSON, expectedMultipleMatchingUri1, servicesJson);
+        MockEndpointPromise promise = new MockEndpointPromise(Method.SUCCESS);
+        service.lookup(promise);
+        waitForComplete(promise);
+        assertTrue("Promise (1) should have been marked done", promise.isComplete());
+
+        service =
+                new MockBluemixEndpointService(Pattern.compile("messagehubincubator"), null, multipleMatchingLabelsJSON, expectedMultipleMatchingUri2, servicesJson);
+        promise = new MockEndpointPromise(Method.SUCCESS);
+        service.lookup(promise);
+        waitForComplete(promise);
+        assertTrue("Promise (2) should have been marked done", promise.isComplete());
+
+        service =
+                new MockBluemixEndpointService(Pattern.compile("user-provided"), null, multipleMatchingLabelsJSON, expectedMultipleMatchingUri3, servicesJson);
+        promise = new MockEndpointPromise(Method.SUCCESS);
+        service.lookup(promise);
+        waitForComplete(promise);
+        assertTrue("Promise (3) should have been marked done", promise.isComplete());
+    }
+
+    // Test golden path for 'user-provided' services.
+    @Test
+    public void userProvidedWorks() throws InterruptedException {
+        BluemixEndpointService service = new MockBluemixEndpointService(userProvidedJSON, expectedUserProvidedUri, servicesJson);
+        MockEndpointPromise promise = new MockEndpointPromise(Method.SUCCESS);
+        service.lookup(promise);
+        waitForComplete(promise);
+        assertTrue("Promise should have been marked done", promise.isComplete());
+    }
+
+    // Test that when there are multiple user-provided services (but only one is
+    // based on the MQ Light service) that the non-MQ Light related services are
+    // ignored.
+    @Test
+    public void userProvidedIgnoresNonMQLight() throws InterruptedException {
+        BluemixEndpointService service = new MockBluemixEndpointService(userProvidedWithNonMQLightJSON, expectedUserProvidedWithNonMQLightUri, servicesJson);
+        MockEndpointPromise promise = new MockEndpointPromise(Method.SUCCESS);
+        service.lookup(promise);
+        waitForComplete(promise);
+        assertTrue("Promise should have been marked done", promise.isComplete());
+    }
 }


### PR DESCRIPTION
Refactor the VCAP_SERVICES parsing to:
- Add the ability to select which service is returned (when there is
  ambiguity, such as multiple instances of the MQ Light service are bound to
  an application)
- Consider services with labels that start 'messagehub' as candidates when
  locating a set of credentials to use.
- Return errors if more than one valid service is found.
- Increase unit test code coverage of this capability.
