### PR TITLE
Handle Throwable raised during user's callback

### DIFF
--- a/mqlight/src/main/java/com/ibm/mqlight/api/impl/callback/ThreadPoolCallbackService.java
+++ b/mqlight/src/main/java/com/ibm/mqlight/api/impl/callback/ThreadPoolCallbackService.java
@@ -25,6 +25,7 @@ import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
+import com.ibm.mqlight.api.ClientRuntimeException;
 import com.ibm.mqlight.api.Promise;
 import com.ibm.mqlight.api.callback.CallbackService;
 import com.ibm.mqlight.api.logging.Logger;
@@ -74,6 +75,14 @@ public class ThreadPoolCallbackService implements CallbackService {
                     promise.setSuccess(null);
                 } catch(Exception e) {
                     promise.setFailure(e);
+                } catch(Throwable t) {
+                    promise.setFailure(new ClientRuntimeException("Throwable raised during callback", t));
+                    synchronized(this) {
+                        if (!promises.isEmpty()) {
+                            executor.submit(this);
+                        }
+                        throw t;
+                    }
                 }
             }
 

--- a/mqlight/src/test/java/com/ibm/mqlight/api/impl/callback/TestThreadPoolCallbackService.java
+++ b/mqlight/src/test/java/com/ibm/mqlight/api/impl/callback/TestThreadPoolCallbackService.java
@@ -52,7 +52,7 @@ public class TestThreadPoolCallbackService {
     
     @Test
     public void exceptionThrownInCallback() throws InterruptedException {
-        CallbackService cbs = new SameThreadCallbackService();
+        CallbackService cbs = new ThreadPoolCallbackService(5);
         MockCallbackPromise promise = new MockCallbackPromise(Method.FAILURE, false);
         final RuntimeException exception = new RuntimeException();
         cbs.run(new Runnable() {
@@ -60,12 +60,28 @@ public class TestThreadPoolCallbackService {
                 throw exception;
             }
         }, new Object(), promise);
-        
+
         assertTrue("Promise should have been completed", promise.waitForComplete(2500));
         assertTrue("Promise should not have been completed successfully", !promise.isSuccessful());
-        assertSame("Exception should have been thrown from run()!", exception, promise.getException().getCause());
+        assertSame("Exception should have been thrown from run()!", exception, promise.getException());
     }
-    
+
+    @Test
+    public void errorThrownInCallback() throws InterruptedException {
+        CallbackService cbs = new ThreadPoolCallbackService(5);
+        MockCallbackPromise promise = new MockCallbackPromise(Method.FAILURE, false);
+        final Error error = new AssertionError();
+        cbs.run(new Runnable() {
+            public void run() {
+                throw error;
+            }
+        }, new Object(), promise);
+
+        assertTrue("Promise should have been completed", promise.waitForComplete(2500));
+        assertTrue("Promise should not have been completed successfully", !promise.isSuccessful());
+        assertSame("Error should have been thrown from run()!", error, promise.getException().getCause());
+    }
+
     static class StressCallbackPromise extends MockCallbackPromise {
         private static final AtomicInteger atomicCount = new AtomicInteger(0);
         private int sequence;


### PR DESCRIPTION
Previously this would cause the promise to remain uncompleted and the
WorkList run() to exit with resetting 'running' to false and hence new
work added to the list would never be actioned.
