### PR TITLE
Fixes to the state machine transitions

### DIFF
--- a/mqlight/src/main/java/com/ibm/mqlight/api/impl/NonBlockingClientImpl.java
+++ b/mqlight/src/main/java/com/ibm/mqlight/api/impl/NonBlockingClientImpl.java
@@ -902,7 +902,8 @@ public class NonBlockingClientImpl extends NonBlockingClient implements FSMActio
                 stateMachine.fire(NonBlockingClientTrigger.REPLACED);
             } else if (error instanceof com.ibm.mqlight.api.NotPermittedException) {
                 if (lastException == null) lastException = (com.ibm.mqlight.api.NotPermittedException) error;
-                stateMachine.fire(NonBlockingClientTrigger.STOP);
+                // XXX: should REPLACED be renamed?  Really it means "server closed the connection - don't retry"
+                stateMachine.fire(NonBlockingClientTrigger.REPLACED);
             } else if (error instanceof com.ibm.mqlight.api.SecurityException) {
                 if (lastException == null) lastException = (com.ibm.mqlight.api.SecurityException) error;
                 stateMachine.fire(NonBlockingClientTrigger.OPEN_RESP_FATAL);

--- a/mqlight/src/main/java/com/ibm/mqlight/api/impl/NonBlockingFSMFactory.java
+++ b/mqlight/src/main/java/com/ibm/mqlight/api/impl/NonBlockingFSMFactory.java
@@ -201,6 +201,7 @@ class NonBlockingFSMFactory {
         config.configure(NonBlockingClientState.Retrying2B)
               .ignore(NonBlockingClientTrigger.START)
               .permit(NonBlockingClientTrigger.OPEN_RESP_OK, NonBlockingClientState.Retrying2C)
+              .permit(NonBlockingClientTrigger.OPEN_RESP_FATAL, NonBlockingClientState.StoppingB)
               .permit(NonBlockingClientTrigger.STOP, NonBlockingClientState.StoppingR2E)
               .permit(NonBlockingClientTrigger.OPEN_RESP_RETRY, NonBlockingClientState.Retrying2A)
               .permit(NonBlockingClientTrigger.NETWORK_ERROR, NonBlockingClientState.Retrying2A)


### PR DESCRIPTION
When the server closes a connection with a NotPermittedException, use the
REPLACED transition rather than the STOPPED transition. This is because the
REPLACED transition is used for the server having closed the connection, where
as STOPPED assumes the client has sent a stop and waits for a response from
the server (which in this case we're not going to get).

Update the FSM to allow a "fatal" response to an open (i.e. server rejects the
client because it is not authorized) when the client is in retrying state. This
is an omission in the original design of the FSM - as we only considered
handling this kind of failure when the client first connects, not when it has
already been connected and is in retrying state.

This fixes the following exception:

```
java.lang.IllegalStateException: No valid leaving transitions are permitted from
state 'Retrying2B' for trigger 'OPEN_RESP_FATAL'. Consider ignoring the trigger.
```
