### PR TITLE
Client with unconfirmed messages won't unsubscribe

### DIFF
--- a/mqlight/src/main/java/com/ibm/mqlight/api/impl/DeliveryImpl.java
+++ b/mqlight/src/main/java/com/ibm/mqlight/api/impl/DeliveryImpl.java
@@ -30,7 +30,7 @@ import com.ibm.mqlight.api.logging.LoggerFactory;
 public abstract class DeliveryImpl implements Delivery {
 
     private static final Logger logger = LoggerFactory.getLogger(DeliveryImpl.class);
-  
+
     private final NonBlockingClientImpl client;
     private final QOS qos;
     private final String share;
@@ -44,7 +44,7 @@ public abstract class DeliveryImpl implements Delivery {
     protected DeliveryImpl(NonBlockingClientImpl client, QOS qos, String share, String topic, String topicPattern, long ttl, Map<String, Object> properties, DeliveryRequest deliveryRequest) {
         final String methodName = "<init>";
         logger.entry(this, methodName, client, qos, share, topic, topicPattern, ttl, properties, deliveryRequest);
-      
+
         this.client = client;
         this.qos = qos;
         this.share = share;
@@ -53,7 +53,7 @@ public abstract class DeliveryImpl implements Delivery {
         this.ttl = ttl;
         this.properties = properties;
         this.deliveryRequest = deliveryRequest;
-        
+
         logger.exit(this, methodName);
     }
 
@@ -64,7 +64,7 @@ public abstract class DeliveryImpl implements Delivery {
     public void confirm() throws StateException {
         final String methodName = "confirm";
         logger.entry(this, methodName);
-      
+
         if (deliveryRequest == null) {
             if (qos == QOS.AT_MOST_ONCE) {
                 throw new StateException("Confirming the receipt of delivery is applicable only when 'at least once' quality of service has been requested");
@@ -75,12 +75,14 @@ public abstract class DeliveryImpl implements Delivery {
             if (confirmed) {
                 throw new StateException("Delivery has already been confirmed");
             } else if (!client.doDelivery(deliveryRequest)) {
-                throw new StateException("Cannot confirm delivery because of an interruption to the network connection to the MQ Light server");
+                throw new StateException("Cannot confirm delivery because of either an interruption to the network "
+                        + "connection to the MQ Light server, or because the client is no longer subscribed to the "
+                        + "destination that the message was received from");
             } else {
                 confirmed = true;
             }
         }
-        
+
         logger.exit(this, methodName);
     }
 

--- a/mqlight/src/main/java/com/ibm/mqlight/api/impl/NonBlockingClientImpl.java
+++ b/mqlight/src/main/java/com/ibm/mqlight/api/impl/NonBlockingClientImpl.java
@@ -805,7 +805,7 @@ public class NonBlockingClientImpl extends NonBlockingClient implements FSMActio
                     }
                     UnsubscribedException se = new UnsubscribedException(errMsg);
                     iu.future.setFailure(se);
-                } else if (sd.pending.isEmpty() && sd.pendingDeliveries.isEmpty()) {
+                } else if (sd.pending.isEmpty()) {
                     if (sd.state == SubData.State.ATTACHING) {
                         pendingWork.addLast(iu);
                     } else if (sd.state == SubData.State.DETATCHING) {
@@ -1308,11 +1308,13 @@ public class NonBlockingClientImpl extends NonBlockingClient implements FSMActio
         boolean result = false;
         if (sd == null) {
             logger.data(methodName, "subscribedDestination not found for " + request.topicPattern);
-        } else {
+        } else if (sd.state == SubData.State.ESTABLISHED) {
             result = (request.qos == QOS.AT_MOST_ONCE || sd.pendingDeliveries.contains(request));
             if (result) {
                 engine.tell(new DeliveryResponse(request), this);
             }
+        } else {
+            logger.data(methodName, "subscription not in ESTABLISHED state for: " + sd);
         }
 
         logger.exit(this, methodName, result);

--- a/mqlight/src/test/java/com/ibm/mqlight/api/impl/TestDestinationListenerWrapper.java
+++ b/mqlight/src/test/java/com/ibm/mqlight/api/impl/TestDestinationListenerWrapper.java
@@ -159,7 +159,7 @@ public class TestDestinationListenerWrapper {
         wrapper.onUnsubscribed(new MockCallbackService(), "", "", null);
     }
 
-    private byte[] createSerializedProtonMessage(AmqpValue body, String topic, long ttl, Map<String, String> properties, Map<Symbol, Object> annotations, String contentType) {
+    public static byte[] createSerializedProtonMessage(AmqpValue body, String topic, long ttl, Map<String, String> properties, Map<Symbol, Object> annotations, String contentType) {
         org.apache.qpid.proton.message.Message protonMsg = Proton.message();
         protonMsg.setBody(body);
         protonMsg.setAddress("amqp:///" + topic);


### PR DESCRIPTION
If a client has unconfirmed messages, there are some conditions when it will not
correctly process a request to unsubscribe from the destination that the
messages were received from. For example: if a QOS1 subscriber with
`autoConfirm=false` attempts to unsubscribe within its onMessage method (without
first confirming delivery of the message) then the unsubscribe request will not
be forwarded to the server - and the operation will never complete.

This seems to have been introduced by commit
c57e4696653b363e296c3c7e30c605a48feab908 and further modified by
commit 973d1c50184b5403a9fc9c55fae1e7208e935c7d which appear to guard against
an exception being raised by the auto-confirm logic if someone unsubscribes
from a topic just at the point a message is being delivered and auto-confirmed.

This commit fixes the problem in a slightly different way: by adding checking
to the confirm message code path which tests the state of the related
subscription before passing the confirm request to the Engine component.
